### PR TITLE
added at-place? argument for effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Reset virtual DOM caching during hot code swapping, and rerender:
 Adding effects to component:
 
 ```clojure
-(defeffect effect-a [text] [action parent-element *local]
+(defeffect effect-a [text] [action parent-element *local at-place?]
   (println action) ; action could be :mount :update :amount
   (when (= :mount action)
     (swap! *local assoc :data "data")))

--- a/calcit.edn
+++ b/calcit.edn
@@ -7595,6 +7595,21 @@
           }
          }
         }
+        "yv" {
+         :type :expr, :by "rJoDgvdeG", :at 1572885674931, :id "yeTXH-rcu8"
+         :data {
+          "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885674931, :text "[]", :id "buBFvLEe5z"}
+          "j" {:type :leaf, :by "rJoDgvdeG", :at 1572885674931, :text "respo.util.list", :id "bbvPStbqwK"}
+          "r" {:type :leaf, :by "rJoDgvdeG", :at 1572885674931, :text ":refer", :id "ayOWvQ3WSn"}
+          "v" {
+           :type :expr, :by "rJoDgvdeG", :at 1572885674931, :id "h4J349LzNv"
+           :data {
+            "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885674931, :text "[]", :id "gyBDwRMKd6"}
+            "j" {:type :leaf, :by "rJoDgvdeG", :at 1572885674931, :text "val-of-first", :id "l6hNrFE0fC"}
+           }
+          }
+         }
+        }
        }
       }
      }
@@ -7710,16 +7725,10 @@
                   :data {
                    "T" {:type :leaf, :id "Sk1ruGe_YCY-", :text "element", :by "root", :at 1504774121421}
                    "j" {
-                    :type :expr, :id "HylBOGe_KAKb", :by nil, :at 1504774121421
+                    :type :expr, :id "rJMBOGx_t0YZ", :by nil, :at 1504774121421
                     :data {
-                     "T" {:type :leaf, :id "rkbHdGldFRK-", :text "last", :by "root", :at 1504774121421}
-                     "j" {
-                      :type :expr, :id "rJMBOGx_t0YZ", :by nil, :at 1504774121421
-                      :data {
-                       "T" {:type :leaf, :id "HymS_GeuKAK-", :text "first", :by "root", :at 1504774121421}
-                       "j" {:type :leaf, :id "rkVSdfluFCtW", :text "new-children", :by "root", :at 1504774121421}
-                      }
-                     }
+                     "T" {:type :leaf, :id "HymS_GeuKAK-", :text "val-of-first", :by "rJoDgvdeG", :at 1572885679872}
+                     "j" {:type :leaf, :id "rkVSdfluFCtW", :text "new-children", :by "root", :at 1504774121421}
                     }
                    }
                   }
@@ -7833,14 +7842,8 @@
                  "v" {
                   :type :expr, :by "rJoDgvdeG", :at 1571582717267, :id "bpUG7FVijs"
                   :data {
-                   "T" {:type :leaf, :by "rJoDgvdeG", :at 1571582720149, :text "last", :id "MrIz9niHw"}
-                   "j" {
-                    :type :expr, :by "rJoDgvdeG", :at 1571582720527, :id "SW8061K-K"
-                    :data {
-                     "T" {:type :leaf, :by "rJoDgvdeG", :at 1571582722592, :text "first", :id "Ja1gAjURmj"}
-                     "j" {:type :leaf, :by "rJoDgvdeG", :at 1571582725457, :text "old-children", :id "3BR0DjP8N8"}
-                    }
-                   }
+                   "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885687366, :text "val-of-first", :id "MrIz9niHw"}
+                   "j" {:type :leaf, :by "rJoDgvdeG", :at 1571582725457, :text "old-children", :id "3BR0DjP8N8"}
                   }
                  }
                  "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885372123, :text "true", :id "_hj2q895ml"}
@@ -8124,14 +8127,8 @@
                          "j" {
                           :type :expr, :id "BkwR_zxdKRtZ", :by nil, :at 1504774121421
                           :data {
-                           "T" {:type :leaf, :id "SJuAuMedK0Fb", :text "last", :by "root", :at 1504774121421}
-                           "j" {
-                            :type :expr, :id "Skt0_fx_FAFb", :by nil, :at 1504774121421
-                            :data {
-                             "T" {:type :leaf, :id "Hkc0_zedK0K-", :text "first", :by "root", :at 1504774121421}
-                             "j" {:type :leaf, :id "SyoA_zx_FAKW", :text "old-children", :by "root", :at 1504774121421}
-                            }
-                           }
+                           "T" {:type :leaf, :id "SJuAuMedK0Fb", :text "val-of-first", :by "rJoDgvdeG", :at 1572885693960}
+                           "j" {:type :leaf, :id "SyoA_zx_FAKW", :text "old-children", :by "root", :at 1504774121421}
                           }
                          }
                         }
@@ -8143,14 +8140,8 @@
                          "j" {
                           :type :expr, :id "HJARufxdKCKW", :by nil, :at 1504774121421
                           :data {
-                           "T" {:type :leaf, :id "HyyyYfldYAFW", :text "last", :by "root", :at 1504774121421}
-                           "j" {
-                            :type :expr, :id "BkxJFGguF0F-", :by nil, :at 1504774121421
-                            :data {
-                             "T" {:type :leaf, :id "BJb1FzedKRYb", :text "first", :by "root", :at 1504774121421}
-                             "j" {:type :leaf, :id "H1fkKzlOtAFZ", :text "new-children", :by "root", :at 1504774121421}
-                            }
-                           }
+                           "T" {:type :leaf, :id "HyyyYfldYAFW", :text "val-of-first", :by "rJoDgvdeG", :at 1572885697500}
+                           "r" {:type :leaf, :id "H1fkKzlOtAFZ", :text "new-children", :by "root", :at 1504774121421}
                           }
                          }
                         }
@@ -8234,14 +8225,8 @@
                              "j" {
                               :type :expr, :id "S1H-KMxOF0tW", :by nil, :at 1504774121421
                               :data {
-                               "T" {:type :leaf, :id "ryUWKfe_tAK-", :text "last", :by "root", :at 1504774121421}
-                               "j" {
-                                :type :expr, :id "H1wWKzlutAKZ", :by nil, :at 1504774121421
-                                :data {
-                                 "T" {:type :leaf, :id "r1uWKfg_KRKZ", :text "first", :by "root", :at 1504774121421}
-                                 "j" {:type :leaf, :id "S1KbYfeOKAt-", :text "new-children", :by "root", :at 1504774121421}
-                                }
-                               }
+                               "T" {:type :leaf, :id "ryUWKfe_tAK-", :text "val-of-first", :by "rJoDgvdeG", :at 1572885701372}
+                               "j" {:type :leaf, :id "S1KbYfeOKAt-", :text "new-children", :by "root", :at 1504774121421}
                               }
                              }
                             }
@@ -8290,14 +8275,8 @@
                        "v" {
                         :type :expr, :by "rJoDgvdeG", :at 1571582780555, :id "xbs2zVMcZ5"
                         :data {
-                         "T" {:type :leaf, :by "rJoDgvdeG", :at 1571582780555, :text "last", :id "I68ZFuQGiI"}
-                         "j" {
-                          :type :expr, :by "rJoDgvdeG", :at 1571582780555, :id "9G_FPqK632"
-                          :data {
-                           "T" {:type :leaf, :by "rJoDgvdeG", :at 1571582780555, :text "first", :id "D4kcJ5N_QO"}
-                           "j" {:type :leaf, :by "rJoDgvdeG", :at 1571582780555, :text "new-children", :id "Df3IdrARM6"}
-                          }
-                         }
+                         "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885703161, :text "val-of-first", :id "I68ZFuQGiI"}
+                         "j" {:type :leaf, :by "rJoDgvdeG", :at 1571582780555, :text "new-children", :id "Df3IdrARM6"}
                         }
                        }
                        "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885088913, :text "true", :id "0upr7CRPZD"}
@@ -8361,14 +8340,8 @@
                        "v" {
                         :type :expr, :by "rJoDgvdeG", :at 1571582795684, :id "aD11tOwb1"
                         :data {
-                         "T" {:type :leaf, :by "rJoDgvdeG", :at 1571582801149, :text "last", :id "cecC6TPPZF"}
-                         "j" {
-                          :type :expr, :by "rJoDgvdeG", :at 1571582801459, :id "2Ww3i6OvEe"
-                          :data {
-                           "T" {:type :leaf, :by "rJoDgvdeG", :at 1571582939148, :text "first", :id "oVV2Lm-23m"}
-                           "j" {:type :leaf, :by "rJoDgvdeG", :at 1571582807176, :text "old-children", :id "EG_zR9K0ZR"}
-                          }
-                         }
+                         "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885709941, :text "val-of-first", :id "cecC6TPPZF"}
+                         "j" {:type :leaf, :by "rJoDgvdeG", :at 1571582807176, :text "old-children", :id "EG_zR9K0ZR"}
                         }
                        }
                        "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885377083, :text "true", :id "3BJkT_pg5y"}
@@ -8514,14 +8487,8 @@
                              "j" {
                               :type :expr, :id "r1MDFfg_tAt-", :by nil, :at 1504774121421
                               :data {
-                               "T" {:type :leaf, :id "rJmvKzxuYAt-", :text "last", :by "root", :at 1504774121421}
-                               "j" {
-                                :type :expr, :id "ry4DtzguYCKb", :by nil, :at 1504774121421
-                                :data {
-                                 "T" {:type :leaf, :id "S1SvtGlutAK-", :text "first", :by "root", :at 1504774121421}
-                                 "j" {:type :leaf, :id "ByUDFMl_F0Kb", :text "new-children", :by "root", :at 1504774121421}
-                                }
-                               }
+                               "T" {:type :leaf, :id "rJmvKzxuYAt-", :text "val-of-first", :by "rJoDgvdeG", :at 1572885715243}
+                               "j" {:type :leaf, :id "ByUDFMl_F0Kb", :text "new-children", :by "root", :at 1504774121421}
                               }
                              }
                             }
@@ -8572,14 +8539,8 @@
                            "v" {
                             :type :expr, :by "rJoDgvdeG", :at 1571582838879, :id "ixzfR6A1G3"
                             :data {
-                             "T" {:type :leaf, :by "rJoDgvdeG", :at 1571582839421, :text "last", :id "UjvFgCenEw"}
-                             "j" {
-                              :type :expr, :by "rJoDgvdeG", :at 1571582942352, :id "sgruaA_2te"
-                              :data {
-                               "D" {:type :leaf, :by "rJoDgvdeG", :at 1571582944095, :text "first", :id "Tge0a-EIg"}
-                               "T" {:type :leaf, :by "root", :at 1571907726206, :text "new-children", :id "bK2jYHeXwc"}
-                              }
-                             }
+                             "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885719154, :text "val-of-first", :id "UjvFgCenEw"}
+                             "j" {:type :leaf, :by "root", :at 1571907726206, :text "new-children", :id "bK2jYHeXwc"}
                             }
                            }
                            "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885091618, :text "true", :id "QFvU9xxp_l"}
@@ -8624,14 +8585,8 @@
                            "v" {
                             :type :expr, :by "rJoDgvdeG", :at 1571582935452, :id "hVN8TBlCSb"
                             :data {
-                             "D" {:type :leaf, :by "rJoDgvdeG", :at 1571582936938, :text "last", :id "Ctq9icKMm"}
-                             "T" {
-                              :type :expr, :by "rJoDgvdeG", :at 1571582929122, :id "mgOxSvx8v3"
-                              :data {
-                               "T" {:type :leaf, :by "rJoDgvdeG", :at 1571582928937, :text "first", :id "avs9Po9mJi"}
-                               "j" {:type :leaf, :by "rJoDgvdeG", :at 1571583030401, :text "old-children", :id "mlrTmnC9w"}
-                              }
-                             }
+                             "D" {:type :leaf, :by "rJoDgvdeG", :at 1572885723417, :text "val-of-first", :id "Ctq9icKMm"}
+                             "T" {:type :leaf, :by "rJoDgvdeG", :at 1571583030401, :text "old-children", :id "mlrTmnC9w"}
                             }
                            }
                            "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885367597, :text "true", :id "Vekpi0pQKleaf"}
@@ -11108,6 +11063,21 @@
           }
          }
         }
+        "v" {
+         :type :expr, :by "rJoDgvdeG", :at 1572885775286, :id "SIURgTM3ak"
+         :data {
+          "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885775606, :text "[]", :id "SIURgTM3akleaf"}
+          "j" {:type :leaf, :by "rJoDgvdeG", :at 1572885779772, :text "respo.util.list", :id "KsmaAOwejk"}
+          "r" {:type :leaf, :by "rJoDgvdeG", :at 1572885780572, :text ":refer", :id "6o2Pn5mbH6"}
+          "v" {
+           :type :expr, :by "rJoDgvdeG", :at 1572885780888, :id "6KgKkmS7Fv"
+           :data {
+            "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885781097, :text "[]", :id "tTpVBTDAOX"}
+            "j" {:type :leaf, :by "rJoDgvdeG", :at 1572885781518, :text "val-of-first", :id "cGc27Wq7_8"}
+           }
+          }
+         }
+        }
        }
       }
      }
@@ -11359,14 +11329,8 @@
                  "v" {
                   :type :expr, :by "rJoDgvdeG", :at 1571586818321, :id "UhSijjgLAyk"
                   :data {
-                   "T" {:type :leaf, :by "rJoDgvdeG", :at 1571586818321, :text "last", :id "dDFrVgzEGUG"}
-                   "j" {
-                    :type :expr, :by "rJoDgvdeG", :at 1571586818321, :id "_MIudMharxV"
-                    :data {
-                     "T" {:type :leaf, :by "rJoDgvdeG", :at 1571586818321, :text "first", :id "d96X4crKqt4"}
-                     "j" {:type :leaf, :by "rJoDgvdeG", :at 1571586818321, :text "children", :id "fB4hXcVcypK"}
-                    }
-                   }
+                   "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885763494, :text "val-of-first", :id "dDFrVgzEGUG"}
+                   "j" {:type :leaf, :by "rJoDgvdeG", :at 1571586818321, :text "children", :id "fB4hXcVcypK"}
                   }
                  }
                  "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885041708, :text "false", :id "imEu5muXX"}
@@ -11662,14 +11626,8 @@
                  "v" {
                   :type :expr, :by "rJoDgvdeG", :at 1571586595529, :id "qQjrTu5ir"
                   :data {
-                   "T" {:type :leaf, :by "rJoDgvdeG", :at 1571586596657, :text "last", :id "wmbIrs6uV"}
-                   "j" {
-                    :type :expr, :by "rJoDgvdeG", :at 1571586603848, :id "C6M2_TNAt"
-                    :data {
-                     "T" {:type :leaf, :by "rJoDgvdeG", :at 1571586604920, :text "first", :id "PhlEbbtCai"}
-                     "j" {:type :leaf, :by "rJoDgvdeG", :at 1571586606923, :text "children", :id "emas3mfbfG"}
-                    }
-                   }
+                   "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885770797, :text "val-of-first", :id "wmbIrs6uV"}
+                   "j" {:type :leaf, :by "rJoDgvdeG", :at 1571586606923, :text "children", :id "emas3mfbfG"}
                   }
                  }
                  "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885308599, :text "false", :id "PUZPi84_Y6"}
@@ -17832,6 +17790,21 @@
           "v" {:type :leaf, :by "root", :at 1529830102848, :text "string", :id "BkA0cRnZQ"}
          }
         }
+        "r" {
+         :type :expr, :by "rJoDgvdeG", :at 1572885810265, :id "2eLSbshUfO"
+         :data {
+          "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885810635, :text "[]", :id "2eLSbshUfOleaf"}
+          "j" {:type :leaf, :by "rJoDgvdeG", :at 1572885816497, :text "respo.util.list", :id "NanIXWJfAp"}
+          "r" {:type :leaf, :by "rJoDgvdeG", :at 1572885817751, :text ":refer", :id "IYs3EpGo_"}
+          "v" {
+           :type :expr, :by "rJoDgvdeG", :at 1572885817942, :id "cu3lZVO4TX"
+           :data {
+            "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885818170, :text "[]", :id "OQTYTJ6GKs"}
+            "j" {:type :leaf, :by "rJoDgvdeG", :at 1572885819155, :text "val-of-first", :id "UvoF1LOlE"}
+           }
+          }
+         }
+        }
        }
       }
      }
@@ -18234,14 +18207,8 @@
                  "j" {
                   :type :expr, :by "root", :at 1529830904553, :id "Sk-bA0nbm"
                   :data {
-                   "D" {:type :leaf, :by "root", :at 1529830914183, :text "last", :id "r1e--R02Z7"}
-                   "T" {
-                    :type :expr, :by "root", :at 1529830584867, :id "H1Wa2A3bQ"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1529830585556, :text "first", :id "r1xTnRhbm"}
-                     "j" {:type :leaf, :by "root", :at 1529830588817, :text "other-children", :id "rJXTnRhZm"}
-                    }
-                   }
+                   "D" {:type :leaf, :by "rJoDgvdeG", :at 1572885804989, :text "val-of-first", :id "r1e--R02Z7"}
+                   "T" {:type :leaf, :by "root", :at 1529830588817, :text "other-children", :id "rJXTnRhZm"}
                   }
                  }
                  "r" {
@@ -20294,6 +20261,32 @@
           :data {
            "T" {:type :leaf, :id "r1zAzMl_tCFW", :text "last", :by "root", :at 1504774121421}
            "j" {:type :leaf, :id "r1m0zzguFCF-", :text "pair", :by "root", :at 1504774121421}
+          }
+         }
+        }
+       }
+      }
+     }
+     "val-of-first" {
+      :type :expr, :by "rJoDgvdeG", :at 1572885625576, :id "8f4vTCRpXu"
+      :data {
+       "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885625576, :text "defn", :id "4DpGZeTcFK"}
+       "j" {:type :leaf, :by "rJoDgvdeG", :at 1572885625576, :text "val-of-first", :id "TKxPWtpiMh"}
+       "r" {
+        :type :expr, :by "rJoDgvdeG", :at 1572885625576, :id "O9ZtDxXQyJ"
+        :data {
+         "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885629777, :text "x", :id "26RwbEtvxv"}
+        }
+       }
+       "v" {
+        :type :expr, :by "rJoDgvdeG", :at 1572885630329, :id "8PTMDct-a1"
+        :data {
+         "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885631743, :text "last", :id "8PTMDct-a1leaf"}
+         "j" {
+          :type :expr, :by "rJoDgvdeG", :at 1572885632356, :id "K0EZT1NSnp"
+          :data {
+           "T" {:type :leaf, :by "rJoDgvdeG", :at 1572885634056, :text "first", :id "kktgXTOMSN"}
+           "j" {:type :leaf, :by "rJoDgvdeG", :at 1572885732132, :text "x", :id "hKEUOKkEg"}
           }
          }
         }

--- a/calcit.edn
+++ b/calcit.edn
@@ -700,6 +700,7 @@
          "T" {:type :leaf, :by "rJoDgvdeG", :at 1571586957133, :text "action", :id "z5zXqom4xMleaf"}
          "j" {:type :leaf, :by "rJoDgvdeG", :at 1571586961474, :text "parent", :id "D3BEmUj4B2"}
          "r" {:type :leaf, :by "rJoDgvdeG", :at 1572086620812, :text "*local", :id "DvBcv4ErB"}
+         "v" {:type :leaf, :by "rJoDgvdeG", :at 1572885426290, :text "at-place?", :id "0O3GiL8pz0"}
         }
        }
        "y" {
@@ -708,6 +709,7 @@
          "T" {:type :leaf, :by "rJoDgvdeG", :at 1571586967079, :text "js/console.log", :id "CuAXbcNa-Nleaf"}
          "j" {:type :leaf, :by "rJoDgvdeG", :at 1571586977512, :text "\"Task effect", :id "Nh9WQ__ZiX"}
          "x" {:type :leaf, :by "rJoDgvdeG", :at 1571586982894, :text "action", :id "QUHWtf6PI"}
+         "y" {:type :leaf, :by "rJoDgvdeG", :at 1572885427880, :text "at-place?", :id "oU7eBqMYH"}
         }
        }
        "yT" {
@@ -6510,6 +6512,7 @@
             }
            }
            "v" {:type :leaf, :by "rJoDgvdeG", :at 1571583164474, :text "element", :id "qJm8xIy9wl"}
+           "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885066295, :text "true", :id "ht9mvFXzj"}
           }
          }
          "wT" {
@@ -6750,6 +6753,7 @@
             }
            }
            "v" {:type :leaf, :by "root", :at 1572231952932, :text "element", :id "AP1TbYl7a7"}
+           "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885203913, :text "true", :id "vsb3TC7b2R"}
           }
          }
          "xj" {
@@ -7757,6 +7761,7 @@
                   }
                  }
                  "v" {:type :leaf, :by "rJoDgvdeG", :at 1571582690804, :text "element", :id "1I3_rhmmMS"}
+                 "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885082770, :text "true", :id "fD_lBcARe"}
                 }
                }
                "v" {
@@ -7838,6 +7843,7 @@
                    }
                   }
                  }
+                 "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885372123, :text "true", :id "_hj2q895ml"}
                 }
                }
                "j" {
@@ -8294,6 +8300,7 @@
                          }
                         }
                        }
+                       "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885088913, :text "true", :id "0upr7CRPZD"}
                       }
                      }
                      "r" {
@@ -8364,6 +8371,7 @@
                          }
                         }
                        }
+                       "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885377083, :text "true", :id "3BJkT_pg5y"}
                       }
                      }
                      "j" {
@@ -8574,6 +8582,7 @@
                              }
                             }
                            }
+                           "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885091618, :text "true", :id "QFvU9xxp_l"}
                           }
                          }
                          "v" {
@@ -8625,6 +8634,7 @@
                              }
                             }
                            }
+                           "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885367597, :text "true", :id "Vekpi0pQKleaf"}
                           }
                          }
                          "j" {
@@ -8832,6 +8842,7 @@
                  "j" {:type :leaf, :by "root", :at 1571645922814, :text "collect!", :id "tsvLxbN5oo"}
                  "r" {:type :leaf, :by "root", :at 1571645922814, :text "n-coord", :id "sCXKWM2dGQ"}
                  "v" {:type :leaf, :by "root", :at 1571645922814, :text "old-tree", :id "m4vZVGE9gV"}
+                 "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885328550, :text "true", :id "WK6XV-FPHq"}
                 }
                }
                "f" {
@@ -8863,6 +8874,7 @@
                  "j" {:type :leaf, :by "root", :at 1571645912685, :text "collect!", :id "pORSjEbiOl"}
                  "r" {:type :leaf, :by "root", :at 1571645912685, :text "n-coord", :id "cFQHKS8Fy4"}
                  "v" {:type :leaf, :by "root", :at 1571645912685, :text "new-tree", :id "skourFt5q1"}
+                 "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885169032, :text "true", :id "H55Dcz5EN9"}
                 }
                }
               }
@@ -8905,6 +8917,7 @@
                "j" {:type :leaf, :by "rJoDgvdeG", :at 1571579471444, :text "collect!", :id "DSAE6dxbU"}
                "r" {:type :leaf, :by "rJoDgvdeG", :at 1571579473607, :text "n-coord", :id "xCEEQtilt"}
                "v" {:type :leaf, :by "rJoDgvdeG", :at 1571579477694, :text "old-tree", :id "qMlaPsdEaR"}
+               "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885332862, :text "true", :id "ZA5xuhp0pW"}
               }
              }
              "j" {
@@ -8977,6 +8990,7 @@
                "j" {:type :leaf, :by "rJoDgvdeG", :at 1571579568348, :text "collect!", :id "KGxvfQgzz9"}
                "r" {:type :leaf, :by "rJoDgvdeG", :at 1571579574796, :text "n-coord", :id "oiRE0qqcU"}
                "v" {:type :leaf, :by "rJoDgvdeG", :at 1571579592238, :text "new-tree", :id "82plVysD4a"}
+               "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885184484, :text "true", :id "_UJUe0E_xp"}
               }
              }
             }
@@ -11109,7 +11123,8 @@
         :data {
          "T" {:type :leaf, :by "rJoDgvdeG", :at 1571579646781, :text "collect!", :id "MmHrCuxTrA"}
          "j" {:type :leaf, :by "rJoDgvdeG", :at 1571579646781, :text "n-coord", :id "jTOW4Lgcx-"}
-         "r" {:type :leaf, :by "rJoDgvdeG", :at 1571586844657, :text "tree", :id "KDVYbCONG7"}
+         "r" {:type :leaf, :by "rJoDgvdeG", :at 1572885009953, :text "tree", :id "KDVYbCONG7"}
+         "v" {:type :leaf, :by "rJoDgvdeG", :at 1572885011584, :text "at-place?", :id "R_2Vj0_5XL"}
         }
        }
        "v" {
@@ -11241,6 +11256,7 @@
                                "j" {:type :leaf, :by "rJoDgvdeG", :at 1572086836106, :text "tree", :id "9Qd9lCVnfE"}
                               }
                              }
+                             "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885046062, :text "at-place?", :id "4iR5Ul2Lc"}
                             }
                            }
                           }
@@ -11270,6 +11286,7 @@
                  "j" {:type :leaf, :by "rJoDgvdeG", :at 1571590471520, :text "tree", :id "AssClb5zDI"}
                 }
                }
+               "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885120720, :text "false", :id "-SuGv-zAG"}
               }
              }
             }
@@ -11352,6 +11369,7 @@
                    }
                   }
                  }
+                 "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885041708, :text "false", :id "imEu5muXX"}
                 }
                }
                "v" {
@@ -11409,6 +11427,7 @@
          "T" {:type :leaf, :by "rJoDgvdeG", :at 1571579661718, :text "collect!", :id "SgJnhLL09n"}
          "j" {:type :leaf, :by "rJoDgvdeG", :at 1571579661718, :text "n-coord", :id "n-NkLqo09g"}
          "r" {:type :leaf, :by "rJoDgvdeG", :at 1571586343497, :text "tree", :id "HMHeMW0BJj"}
+         "v" {:type :leaf, :by "rJoDgvdeG", :at 1572885289598, :text "at-place?", :id "Pyn5IWolZv"}
         }
        }
        "v" {
@@ -11460,6 +11479,7 @@
                  "j" {:type :leaf, :by "rJoDgvdeG", :at 1571590486108, :text "tree", :id "u0obmzpQmD"}
                 }
                }
+               "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885305363, :text "false", :id "2vZ4Yr15Z"}
               }
              }
              "j" {
@@ -11555,6 +11575,7 @@
                                "j" {:type :leaf, :by "rJoDgvdeG", :at 1572086856961, :text "tree", :id "9bIxpnSuB7"}
                               }
                              }
+                             "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885460369, :text "at-place?", :id "t6Hs_zJwg"}
                             }
                            }
                           }
@@ -11651,6 +11672,7 @@
                    }
                   }
                  }
+                 "x" {:type :leaf, :by "rJoDgvdeG", :at 1572885308599, :text "false", :id "PUZPi84_Y6"}
                 }
                }
                "T" {

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,7 +1,7 @@
 
 {:pom {:group-id "respo",
        :artifact-id "respo",
-       :version "0.11.4",
+       :version "0.11.5-a1",
        :name "Respo: A virtual DOM library in ClojureScript."}
  :packaging {:jar {:enabled true
                    :remote-repository {:id "clojars"

--- a/src/respo/app/comp/task.cljs
+++ b/src/respo/app/comp/task.cljs
@@ -11,8 +11,8 @@
 (defeffect
  effect-log
  (task)
- (action parent *local)
- (js/console.log "Task effect" action)
+ (action parent *local at-place?)
+ (js/console.log "Task effect" action at-place?)
  (case action
    :mount (let [x0 (js/Math.random)] (swap! *local assoc :data x0) (println "Stored" x0))
    :update (println "read" (get @*local :data))

--- a/src/respo/core.cljs
+++ b/src/respo/core.cljs
@@ -75,7 +75,7 @@
                    (swap! *changes conj x))]
     (comment println "mount app")
     (activate-instance! (purify-element element) target deliver-event)
-    (collect-mounting collect! [] element)
+    (collect-mounting collect! [] element true)
     (patch-instance! @*changes target deliver-event)
     (reset! *global-element element)
     (reset! *dom-element element)))
@@ -92,7 +92,7 @@
         deliver-event (build-deliver-event *global-element dispatch!)]
     (if (nil? app-element) (throw (js/Error. "Detected no element from SSR!")))
     (compare-to-dom! (purify-element element) app-element)
-    (collect-mounting collect! [] element)
+    (collect-mounting collect! [] element true)
     (patch-instance! @*changes target deliver-event)
     (reset! *global-element (mute-element element))
     (reset! *dom-element element)))

--- a/src/respo/render/diff.cljs
+++ b/src/respo/render/diff.cljs
@@ -100,17 +100,17 @@
          (find-element-diffs collect! n-coord (:tree old-tree) (:tree new-tree))
          (collect-updating collect! :update n-coord old-tree new-tree))
         (do
-         (collect-unmounting collect! n-coord old-tree)
+         (collect-unmounting collect! n-coord old-tree true)
          (find-element-diffs collect! n-coord (:tree old-tree) (:tree new-tree))
-         (collect-mounting collect! n-coord new-tree)))
+         (collect-mounting collect! n-coord new-tree true)))
     (and (component? old-tree) (element? new-tree))
       (do
-       (collect-unmounting collect! n-coord old-tree)
+       (collect-unmounting collect! n-coord old-tree true)
        (recur collect! n-coord (:tree old-tree) new-tree))
     (and (element? old-tree) (component? new-tree))
       (do
        (find-element-diffs collect! n-coord old-tree (:tree new-tree))
-       (collect-mounting collect! n-coord new-tree))
+       (collect-mounting collect! n-coord new-tree true))
     (and (element? old-tree) (element? new-tree))
       (let [old-children (:children old-tree), new-children (:children new-tree)]
         (if (or (not= (:coord old-tree) (:coord new-tree))
@@ -140,11 +140,11 @@
       (and was-empty? (not now-empty?))
         (let [element (last (first new-children))]
           (collect! [op/append-element n-coord (purify-element element)])
-          (collect-mounting collect! (conj n-coord index) element)
+          (collect-mounting collect! (conj n-coord index) element true)
           (recur collect! n-coord (inc index) [] (rest new-children)))
       (and (not was-empty?) now-empty?)
         (do
-         (collect-unmounting collect! (conj n-coord index) (last (first old-children)))
+         (collect-unmounting collect! (conj n-coord index) (last (first old-children)) true)
          (collect! [op/rm-element (conj n-coord index) nil])
          (recur collect! n-coord index (rest old-children) []))
       :else
@@ -170,14 +170,19 @@
                (collect!
                 (let [element (last (first new-children))]
                   [op/add-element (conj n-coord index) (purify-element element)]))
-               (collect-mounting collect! (conj n-coord index) (last (first new-children)))
+               (collect-mounting
+                collect!
+                (conj n-coord index)
+                (last (first new-children))
+                true)
                (recur collect! n-coord (inc index) old-children new-follows))
             (and (not x1-remains?) y1-existed?)
               (do
                (collect-unmounting
                 collect!
                 (conj n-coord index)
-                (last (first old-children)))
+                (last (first old-children))
+                true)
                (collect! [op/rm-element (conj n-coord index) nil])
                (recur collect! n-coord index old-follows new-children))
             :else
@@ -193,12 +198,14 @@
                     (collect-mounting
                      collect!
                      (conj n-coord index)
-                     (last (first new-children)))
+                     (last (first new-children))
+                     true)
                     (recur collect! n-coord (inc index) old-children new-follows))
                   (do
                    (collect-unmounting
                     collect!
                     (conj n-coord index)
-                    (last (first old-children)))
+                    (last (first old-children))
+                    true)
                    (collect! [op/rm-element (conj n-coord index) nil])
                    (recur collect! n-coord index old-follows new-children)))))))))

--- a/src/respo/render/diff.cljs
+++ b/src/respo/render/diff.cljs
@@ -8,7 +8,8 @@
             [respo.util.comparator :refer [compare-xy]]
             [respo.render.effect
              :refer
-             [collect-mounting collect-updating collect-unmounting]]))
+             [collect-mounting collect-updating collect-unmounting]]
+            [respo.util.list :refer [val-of-first]]))
 
 (declare find-children-diffs)
 
@@ -138,13 +139,13 @@
     (cond
       (and was-empty? now-empty?) nil
       (and was-empty? (not now-empty?))
-        (let [element (last (first new-children))]
+        (let [element (val-of-first new-children)]
           (collect! [op/append-element n-coord (purify-element element)])
           (collect-mounting collect! (conj n-coord index) element true)
           (recur collect! n-coord (inc index) [] (rest new-children)))
       (and (not was-empty?) now-empty?)
         (do
-         (collect-unmounting collect! (conj n-coord index) (last (first old-children)) true)
+         (collect-unmounting collect! (conj n-coord index) (val-of-first old-children) true)
          (collect! [op/rm-element (conj n-coord index) nil])
          (recur collect! n-coord index (rest old-children) []))
       :else
@@ -161,19 +162,19 @@
           (comment println "compare:" x1 new-keys x1-remains? y1 y1-existed? old-keys)
           (cond
             (= x1 y1)
-              (let [old-element (last (first old-children))
-                    new-element (last (first new-children))]
+              (let [old-element (val-of-first old-children)
+                    new-element (val-of-first new-children)]
                 (find-element-diffs collect! (conj n-coord index) old-element new-element)
                 (recur collect! n-coord (inc index) old-follows new-follows))
             (and x1-remains? (not y1-existed?))
               (do
                (collect!
-                (let [element (last (first new-children))]
+                (let [element (val-of-first new-children)]
                   [op/add-element (conj n-coord index) (purify-element element)]))
                (collect-mounting
                 collect!
                 (conj n-coord index)
-                (last (first new-children))
+                (val-of-first new-children)
                 true)
                (recur collect! n-coord (inc index) old-children new-follows))
             (and (not x1-remains?) y1-existed?)
@@ -181,7 +182,7 @@
                (collect-unmounting
                 collect!
                 (conj n-coord index)
-                (last (first old-children))
+                (val-of-first old-children)
                 true)
                (collect! [op/rm-element (conj n-coord index) nil])
                (recur collect! n-coord index old-follows new-children))
@@ -192,20 +193,20 @@
                     first-new-entry (first new-children)]
                 (comment println "index:" xi yi)
                 (if (<= xi yi)
-                  (let [new-element (last (first new-children))]
+                  (let [new-element (val-of-first new-children)]
                     (collect!
                      [op/add-element (conj n-coord index) (purify-element new-element)])
                     (collect-mounting
                      collect!
                      (conj n-coord index)
-                     (last (first new-children))
+                     (val-of-first new-children)
                      true)
                     (recur collect! n-coord (inc index) old-children new-follows))
                   (do
                    (collect-unmounting
                     collect!
                     (conj n-coord index)
-                    (last (first old-children))
+                    (val-of-first old-children)
                     true)
                    (collect! [op/rm-element (conj n-coord index) nil])
                    (recur collect! n-coord index old-follows new-children)))))))))

--- a/src/respo/render/effect.cljs
+++ b/src/respo/render/effect.cljs
@@ -1,6 +1,8 @@
 
 (ns respo.render.effect
-  (:require [respo.schema.op :as op] [respo.util.detect :refer [component? element? =seq]]))
+  (:require [respo.schema.op :as op]
+            [respo.util.detect :refer [component? element? =seq]]
+            [respo.util.list :refer [val-of-first]]))
 
 (defn collect-mounting [collect! n-coord tree at-place?]
   (cond
@@ -18,7 +20,7 @@
     (element? tree)
       (loop [children (:children tree), idx 0]
         (when-not (empty? children)
-          (collect-mounting collect! (conj n-coord idx) (last (first children)) false)
+          (collect-mounting collect! (conj n-coord idx) (val-of-first children) false)
           (recur (rest children) (inc idx))))
     :else (js/console.warn "Unknown entry for mounting:" tree)))
 
@@ -38,7 +40,7 @@
     (element? tree)
       (loop [children (:children tree), idx 0]
         (when-not (empty? children)
-          (collect-unmounting collect! (conj n-coord idx) (last (first children)) false)
+          (collect-unmounting collect! (conj n-coord idx) (val-of-first children) false)
           (recur (rest children) (inc idx))))
     :else (js/console.warn "Unknown entry for unmounting:" tree)))
 

--- a/src/respo/util/dom.cljs
+++ b/src/respo/util/dom.cljs
@@ -1,5 +1,6 @@
 
-(ns respo.util.dom (:require [clojure.string :as string]))
+(ns respo.util.dom
+  (:require [clojure.string :as string] [respo.util.list :refer [val-of-first]]))
 
 (defn compare-to-dom! [vdom element]
   (comment println "compare" (:name vdom) (map :name (vals (:children vdom))))
@@ -23,7 +24,7 @@
     (let [real-children (.-children element)]
       (loop [acc 0, other-children (:children vdom)]
         (when (not (empty? other-children))
-          (compare-to-dom! (last (first other-children)) (aget real-children acc))
+          (compare-to-dom! (val-of-first other-children) (aget real-children acc))
           (recur (inc acc) (rest other-children)))))))
 
 (def shared-canvas-context

--- a/src/respo/util/list.cljs
+++ b/src/respo/util/list.cljs
@@ -31,3 +31,5 @@
         (into {}))))
 
 (defn val-exists? [pair] (some? (last pair)))
+
+(defn val-of-first [x] (last (first x)))


### PR DESCRIPTION
`at-place?` checks if mounting/unmounting happen directly at this component, and assigned as `true`. Child components also trigger mount/unmount hooks, but with `at-place?` being `false`. It can be useful when we need to disable DOM operations when a component is removed with it's parents.
