### PR TITLE
Breaking: refactor states

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,47 @@
+
+name: Deploy package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    name: Deploy
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: curl -O https://download.clojure.org/install/linux-install-1.10.1.507.sh && chmod +x linux-install-1.10.1.507.sh && sudo ./linux-install-1.10.1.507.sh
+
+      - uses: actions/checkout@v2
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        name: Cache node modules of yarn
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Cache Clojars
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-clojars
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('shadow-cljs.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clojars
+
+      - name: run tests
+        run: 'yarn && yarn shadow-cljs compile client'
+
+      - run: echo Working on ${{ github.ref }}
+
+      - name: deploy to clojars
+        run: env CLOJARS_USERNAME=jiyinyiyong CLOJARS_PASSWORD=${{ secrets.CLOJARS_PASSWORD }} clojure -A:release

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,9 @@ jobs:
             ${{ runner.os }}-clojars
 
       - name: run tests
-        run: 'yarn && yarn shadow-cljs compile client'
+        run: 'yarn && yarn shadow-cljs compile app test'
+
+      - run: node target/test.js
 
       - run: echo Working on ${{ github.ref }}
 

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -1,0 +1,55 @@
+
+name: Upload Assets
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+
+jobs:
+  upload-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker://timbru31/java-node:latest
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        name: Cache node modules of yarn
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Cache Clojars
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-clojars
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('shadow-cljs.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clojars
+
+      - run: yarn && yarn build
+        name: Build web assets
+
+      - name: Deploy to server
+        id: deploy
+        uses: Pendect/action-rsyncer@v1.1.0
+        env:
+          DEPLOY_KEY: ${{secrets.rsync_private_key}}
+        with:
+          flags: '-avzr --progress'
+          options: ''
+          ssh_options: ''
+          src: 'dist/*'
+          dest: 'rsync-user@tiye.me:/web-assets/repo/${{ github.repository }}'
+
+      - name: Display status from deploy
+        run: echo "${{ steps.deploy.outputs.status }}"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Respo: A virtual DOM library in ClojureScript
 [![Respo](https://img.shields.io/clojars/v/respo/respo.svg)](https://clojars.org/respo/respo)
 
 ```clojure
-[respo "0.11.5"]
+[respo "0.12.0-a1"]
 ```
 
 * Home http://respo-mvc.org
@@ -21,7 +21,7 @@ DOM syntax
 ```clojure
 (div {:class-name "demo-container"
       :style {:color :red}
-      :on-click (fn [event dispatch! mutate!])}
+      :on-click (fn [event dispatch!])}
       (div {}))
 ```
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -167,7 +167,7 @@
                         |r $ {} (:type :leaf) (:id |ry6eyeMxuKRKW) (:text |div) (:by |root) (:at 1504774121421)
                         |v $ {} (:type :leaf) (:id |S1Ae1eGlOY0FZ) (:text |span) (:by |root) (:at 1504774121421)
                         |x $ {} (:type :leaf) (:id |B11ZygfxOYCF-) (:text |<>) (:by |root) (:at 1504774121421)
-                        |y $ {} (:type :leaf) (:id |r1g-yxMguK0tZ) (:text |cursor->) (:by |root) (:at 1504774121421)
+                        |yT $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718739742) (:text |>>) (:id |Bwj3jOdhNV)
                 |r $ {} (:type :expr) (:id |Sy5-yxzx_KCYW) (:by nil) (:at 1504774121421)
                   :data $ {}
                     |T $ {} (:type :leaf) (:id |Bks-JxGl_Y0tb) (:text |[]) (:by |root) (:at 1504774121421)
@@ -192,7 +192,7 @@
                     :data $ {}
                       |T $ {} (:type :expr) (:id |ByfQJxMxdKRFb) (:by nil) (:at 1504774121421)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:id |SyXm1gGxOYCKZ) (:text |state) (:by |root) (:at 1504774121421)
+                          |T $ {} (:type :leaf) (:id |SyXm1gGxOYCKZ) (:text |states) (:by |rJoDgvdeG) (:at 1584718727659)
                           |j $ {} (:type :expr) (:id |H14X1efxuKCtb) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |S1S71efxutCtW) (:text |:states) (:by |root) (:at 1504774121421)
@@ -209,10 +209,13 @@
                               |j $ {} (:type :leaf) (:id |rJT7kezgdtRFW) (:text |style-global) (:by |root) (:at 1504774121421)
                       |r $ {} (:type :expr) (:id |rkCmygfeOFRKb) (:by nil) (:at 1504774121421)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:id |rJkNkeMguYRFb) (:text |cursor->) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :leaf) (:id |Hyg4kxGldKAKW) (:text |:todolist) (:by |root) (:at 1504774121421)
                           |r $ {} (:type :leaf) (:id |SJb4JeMx_FCKb) (:text |comp-todolist) (:by |root) (:at 1504774121421)
-                          |v $ {} (:type :leaf) (:id |rJGEJgGxuKRFZ) (:text |state) (:by |root) (:at 1504774121421)
+                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718730076)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:id |rJGEJgGxuKRFZ) (:text |states) (:by |rJoDgvdeG) (:at 1584718729784)
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718731141) (:text |>>) (:id |ISElzMlt1f)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718737043) (:text |:todolist) (:id |oP7XD2rx5)
+                            :id |XDzkqmpzT
                           |x $ {} (:type :expr) (:id |S1RlBXcCb) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |HyV41lzeuKCtW) (:text |:tasks) (:by |root) (:at 1504774121421)
@@ -1658,15 +1661,6 @@
                     |j $ {} (:type :leaf) (:id |rkMPbxMl_KRFW) (:text |clojure.string) (:by |root) (:at 1504774121421)
                     |r $ {} (:type :leaf) (:id |SkQvbgGgOtRYW) (:text |:as) (:by |root) (:at 1504774121421)
                     |v $ {} (:type :leaf) (:id |Bk4vbxfxOFCKb) (:text |string) (:by |root) (:at 1504774121421)
-                |r $ {} (:type :expr) (:id |BySDWxzldFCKZ) (:by nil) (:at 1504774121421)
-                  :data $ {}
-                    |T $ {} (:type :leaf) (:id |H18PZeMlutRYW) (:text |[]) (:by |root) (:at 1504774121421)
-                    |j $ {} (:type :leaf) (:id |r1DwbgGe_Y0K-) (:text |respo.cursor) (:by |root) (:at 1504774121421)
-                    |r $ {} (:type :leaf) (:id |r1uv-xGldFAKb) (:text |:refer) (:by |root) (:at 1504774121421)
-                    |v $ {} (:type :expr) (:id |rJYPZezxutCFW) (:by nil) (:at 1504774121421)
-                      :data $ {}
-                        |T $ {} (:type :leaf) (:id |BkqwZeGgOF0YZ) (:text |[]) (:by |root) (:at 1504774121421)
-                        |j $ {} (:type :leaf) (:id |BksDblzedFCYb) (:text |mutate) (:by |root) (:at 1504774121421)
         :defs $ {}
           |updater $ {} (:type :expr) (:id |SJaDbeMxOKAY-) (:by nil) (:at 1504774121421)
             :data $ {}
@@ -1872,15 +1866,25 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:id |HyOcbeGgOFRKW) (:text |conj) (:by |root) (:at 1504774121421)
                                   |j $ {} (:type :leaf) (:id |SkFcZgGxOKCKW) (:text |tasks) (:by |root) (:at 1504774121421)
-                                  |r $ {} (:type :expr) (:id |BJcc-eGxdtRKW) (:by nil) (:at 1504774121421)
+                                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719381815)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:id |SJicZeMlOK0K-) (:text |{}) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :leaf) (:id |Bkh9-xfgOKAtZ) (:text |:text) (:by |root) (:at 1504774121421)
-                                      |r $ {} (:type :leaf) (:id |H1p5WgGguYRF-) (:text |op-data) (:by |root) (:at 1504774121421)
-                                      |v $ {} (:type :leaf) (:id |H105-lMlOKRtZ) (:text |:id) (:by |root) (:at 1504774121421)
-                                      |x $ {} (:type :leaf) (:id |S1kj-efe_tAYb) (:text |op-id) (:by |root) (:at 1504774121421)
-                                      |y $ {} (:type :leaf) (:id |HkxobxfedtCtb) (:text |:done?) (:by |root) (:at 1504774121421)
-                                      |yT $ {} (:type :leaf) (:id |ByWsWxzgOt0Y-) (:text |false) (:by |root) (:at 1504774121421)
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719382396) (:text |{}) (:id |6qYiMSqtIleaf)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719382680)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719383870) (:text |:text) (:id |6Sj7fTAQ8x)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719384757) (:text |op-data) (:id |33NLpqRmMr)
+                                        :id |MCfeYmvyCE
+                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719385270)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719385873) (:text |:id) (:id |Z06-bUKWGUleaf)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719386694) (:text |op-id) (:id |HmAzRUOd4v)
+                                        :id |Z06-bUKWGU
+                                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719387463)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719388784) (:text |:done?) (:id |g3WrtUGUOFleaf)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719389569) (:text |false) (:id |elWIvrdJ3e)
+                                        :id |g3WrtUGUOF
+                                    :id |6qYiMSqtI
                   |yj $ {} (:type :expr) (:id |SkmezxfeOY0tW) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |Hk4gflMx_tAY-) (:text |:hit-first) (:by |root) (:at 1504774121421)
@@ -1911,15 +1915,44 @@
                   |r $ {} (:type :expr) (:id |S14tbezeuFCKW) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |HkHKZlzldFCYb) (:text |:states) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :expr) (:id |HJLKbgzgOY0tb) (:by nil) (:at 1504774121421)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719281795)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:id |H1PtbgfgOt0t-) (:text |update) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :leaf) (:id |H1dKZxzgdKRYW) (:text |store) (:by |root) (:at 1504774121421)
-                          |r $ {} (:type :leaf) (:id |ByKYZxMx_t0KW) (:text |:states) (:by |root) (:at 1504774121421)
-                          |v $ {} (:type :expr) (:id |BkctWlGgdKAtb) (:by nil) (:at 1504774121421)
+                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719302329)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:id |S1jtWezeutAY-) (:text |mutate) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :leaf) (:id |H13YWxGlOtAKZ) (:text |op-data) (:by |root) (:at 1504774121421)
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719304502) (:text |assoc-in) (:id |l02JsLTi7r)
+                              |L $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719307293) (:text |store) (:id |brSNOSBVi)
+                              |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719308706)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719309808) (:text |concat) (:id |BR1lID9d8B)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719314018)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719313746) (:text |[]) (:id |6MOBpGeLaG)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719315187) (:text |:states) (:id |IiwsJoTlH)
+                                    :id |QXBJpeW9_X
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584720021464)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720021464) (:text |[]) (:id |WwLoecb2QN)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720021464) (:text |:data) (:id |RCLhbCJLN6)
+                                    :id |rDMUTOeVFO
+                                  |n $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720024620) (:text |cursor) (:id |ALEP1pX4U2)
+                                :id |93m25QYs8c
+                              |h $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719332522) (:text |new-state) (:id |OYTbB_Mi0)
+                            :id |CxgPWiu1h2
+                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719283402) (:text |let) (:id |eGVwNOn-R)
+                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719283638)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719283851)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719287121)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719284014) (:text |[]) (:id |mL2a52JhPv)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719288288) (:text |cursor) (:id |W8PyCjY3NX)
+                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719293770) (:text |new-state) (:id |-cSCygN5IU)
+                                    :id |9ELfWGgok
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719298030) (:text |op-data) (:id |sa_-pEQZB)
+                                :id |iAjFXXTh_u
+                            :id |2vLlZTdipJ
+                        :id |m6XwoLiTL
                   |y $ {} (:type :expr) (:id |rkT3ZgzlOYRKZ) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |Bk0nZxfedKCFW) (:text |:clear) (:by |root) (:at 1504774121421)
@@ -2353,35 +2386,56 @@
                   |j $ {} (:type :leaf) (:id |rkVMWe_tRY-) (:text |op-data) (:by |root) (:at 1504774121421)
               |v $ {} (:type :expr) (:id |SyHGZx_KRtW) (:by nil) (:at 1504774121421)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:id |B1UfWl_K0tZ) (:text |;) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |r1PfblutRYW) (:text |println) (:by |root) (:at 1504774121421)
                   |r $ {} (:type :leaf) (:id |ByOfWeuKAFb) (:text |op) (:by |root) (:at 1504774121421)
-              |x $ {} (:type :expr) (:id |HkFz-ldYAFb) (:by nil) (:at 1504774121421)
+                  |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720061550) (:text |op-data) (:id |hyWaq1V-N)
+                  |L $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720208804) (:text |;) (:id |zNr_JsfkXh)
+              |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718843689)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:id |rJ9fZg_tRtZ) (:text |let) (:by |root) (:at 1504774121421)
-                  |j $ {} (:type :expr) (:id |H1if-guKAKZ) (:by nil) (:at 1504774121421)
+                  |T $ {} (:type :expr) (:id |HkFz-ldYAFb) (:by nil) (:at 1504774121421)
                     :data $ {}
-                      |T $ {} (:type :expr) (:id |SJnf-eOYCKZ) (:by nil) (:at 1504774121421)
+                      |T $ {} (:type :leaf) (:id |rJ9fZg_tRtZ) (:text |let) (:by |root) (:at 1504774121421)
+                      |j $ {} (:type :expr) (:id |H1if-guKAKZ) (:by nil) (:at 1504774121421)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:id |By6f-lOYRFZ) (:text |op-id) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :expr) (:id |SyCGbg_KAtb) (:by nil) (:at 1504774121421)
+                          |T $ {} (:type :expr) (:id |SJnf-eOYCKZ) (:by nil) (:at 1504774121421)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:id |ByJX-xdtRFW) (:text |get-id!) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :expr) (:id |rkgQZl_KCYW) (:by nil) (:at 1504774121421)
+                              |T $ {} (:type :leaf) (:id |By6f-lOYRFZ) (:text |op-id) (:by |root) (:at 1504774121421)
+                              |j $ {} (:type :expr) (:id |SyCGbg_KAtb) (:by nil) (:at 1504774121421)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:id |ByJX-xdtRFW) (:text |get-id!) (:by |root) (:at 1504774121421)
+                          |j $ {} (:type :expr) (:id |rkgQZl_KCYW) (:by nil) (:at 1504774121421)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:id |BkZX-gOKAtW) (:text |store) (:by |root) (:at 1504774121421)
+                              |j $ {} (:type :expr) (:id |SyfXZlOYCK-) (:by nil) (:at 1504774121421)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:id |rk7mWluKRK-) (:text |updater) (:by |root) (:at 1504774121421)
+                                  |j $ {} (:type :leaf) (:id |Hk4XbldKRtW) (:text |@*store) (:by |root) (:at 1504774121421)
+                                  |r $ {} (:type :leaf) (:id |B1BQWguKRtb) (:text |op) (:by |root) (:at 1504774121421)
+                                  |v $ {} (:type :leaf) (:id |HJUm-xdtCYZ) (:text |op-data) (:by |root) (:at 1504774121421)
+                                  |x $ {} (:type :leaf) (:id |SkvQZl_K0YW) (:text |op-id) (:by |root) (:at 1504774121421)
+                      |r $ {} (:type :expr) (:id |r1_QbxdFRY-) (:by nil) (:at 1504774121421)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:id |BkZX-gOKAtW) (:text |store) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :expr) (:id |SyfXZlOYCK-) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |rk7mWluKRK-) (:text |updater) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :leaf) (:id |Hk4XbldKRtW) (:text |@*store) (:by |root) (:at 1504774121421)
-                              |r $ {} (:type :leaf) (:id |B1BQWguKRtb) (:text |op) (:by |root) (:at 1504774121421)
-                              |v $ {} (:type :leaf) (:id |HJUm-xdtCYZ) (:text |op-data) (:by |root) (:at 1504774121421)
-                              |x $ {} (:type :leaf) (:id |SkvQZl_K0YW) (:text |op-id) (:by |root) (:at 1504774121421)
-                  |r $ {} (:type :expr) (:id |r1_QbxdFRY-) (:by nil) (:at 1504774121421)
+                          |T $ {} (:type :leaf) (:id |SkYm-lOKAtb) (:text |reset!) (:by |root) (:at 1504774121421)
+                          |j $ {} (:type :leaf) (:id |B19mWe_YAKZ) (:text |*store) (:by |root) (:at 1504774121421)
+                          |r $ {} (:type :leaf) (:id |ByiX-eOFRKb) (:text |store) (:by |root) (:at 1504774121421)
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718846122) (:text |if) (:id |rwCjbrep9i)
+                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718846341)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:id |SkYm-lOKAtb) (:text |reset!) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:id |B19mWe_YAKZ) (:text |*store) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :leaf) (:id |ByiX-eOFRKb) (:text |store) (:by |root) (:at 1504774121421)
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718847761) (:text |vector?) (:id |e2kWuNqsAy)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718848314) (:text |op) (:id |iDmLrFqz0f)
+                    :id |7rdYnKFiv4
+                  |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718851481)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718853699) (:text |recur) (:id |Dii4pQIwH9leaf)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718857610) (:text |:states) (:id |vyPf5DcgTP)
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718858433)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718858662) (:text |[]) (:id |jJsI95oC9)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718859744) (:text |op) (:id |cnh-B1xHb4)
+                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718863792) (:text |op-data) (:id |HiMr8pqSj)
+                        :id |5HV7o9OKLN
+                    :id |Dii4pQIwH9
+                :id |-QS2jDfwiR
           |handle-ssr! $ {} (:type :expr) (:by |root) (:at 1529814786924) (:id |ByeiWko2-Q)
             :data $ {}
               |T $ {} (:type :leaf) (:by |root) (:at 1529814786924) (:text |defn) (:id |HybiWyi2Wm)
@@ -2909,6 +2963,14 @@
                       |j $ {} (:type :expr) (:id |SyyMvze_tCYb) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:id |rJlfPMeOt0tW) (:text |{}) (:by |root) (:at 1504774121421)
+                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717665248)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717667420) (:text |:cursor) (:id |RLM2OgdvDleaf)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717667697)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717667935) (:text |[]) (:id |amjXn0LFi2)
+                        :id |lKzQL0hFF0
+                    :id |RLM2OgdvD
           |task $ {} (:type :expr) (:id |HkIxvfldY0K-) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:id |rkwgDMeuYAFb) (:text |def) (:by |root) (:at 1504774121421)
@@ -5690,49 +5752,6 @@
               |j $ {} (:type :leaf) (:text |add-element) (:id |HkfJ7Yf5zf) (:by |root) (:at 1513920790595)
               |r $ {} (:type :leaf) (:text |0) (:id |rJ_4FfqGf) (:by |root) (:at 1513920815969)
         :proc $ {} (:type :expr) (:id |SJm20_G9fz) (:by |root) (:at 1513920723777) (:data $ {})
-      |respo.cursor $ {}
-        :ns $ {} (:type :expr) (:id |BkvtAzg_tAtb) (:by nil) (:at 1504774121421)
-          :data $ {}
-            |T $ {} (:type :leaf) (:id |BJOK0GxOYAYb) (:text |ns) (:by |root) (:at 1504774121421)
-            |j $ {} (:type :leaf) (:id |rkYt0MeOF0Fb) (:text |respo.cursor) (:by |root) (:at 1504774121421)
-        :defs $ {}
-          |mutate $ {} (:type :expr) (:id |ByiFRGgOKAYb) (:by nil) (:at 1504774121421)
-            :data $ {}
-              |T $ {} (:type :leaf) (:id |Sk2KCfx_FRKZ) (:text |defn) (:by |root) (:at 1504774121421)
-              |j $ {} (:type :leaf) (:id |rJaFRMl_KCKW) (:text |mutate) (:by |root) (:at 1504774121421)
-              |r $ {} (:type :expr) (:id |H10tCGedKCY-) (:by nil) (:at 1504774121421)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:id |SJk9RGl_YRFb) (:text |op-data) (:by |root) (:at 1504774121421)
-              |v $ {} (:type :expr) (:id |Bkl5RGl_KCYZ) (:by nil) (:at 1504774121421)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:id |rkZ5CMl_tAFW) (:text |fn) (:by |root) (:at 1504774121421)
-                  |j $ {} (:type :expr) (:id |HkzqRMlOFRKZ) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |HkQc0zxdKCFb) (:text |states) (:by |root) (:at 1504774121421)
-                  |r $ {} (:type :expr) (:id |BJEqRfeuKRK-) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |SyS9RflOtRYZ) (:text |let) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :expr) (:id |rkUcRGldKAK-) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :expr) (:id |H1D9AGe_K0YW) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :expr) (:id |SJ_9CMldKAtZ) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |r1KcCGedY0KZ) (:text |[]) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :leaf) (:id |rJc9AGeOKRKW) (:text |cursor) (:by |root) (:at 1504774121421)
-                                  |r $ {} (:type :leaf) (:id |Hks5Azl_Y0FW) (:text |next-state) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :leaf) (:id |HJ3q0Gx_KCFW) (:text |op-data) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :expr) (:id |Bk6qCzx_KRKW) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:id |HJ05Cfxut0KW) (:text |assoc-in) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :leaf) (:id |ryJoAMlOtCFW) (:text |states) (:by |root) (:at 1504774121421)
-                          |r $ {} (:type :expr) (:id |HkejAzx_FAtZ) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |Sk-jAfguFRY-) (:text |conj) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :leaf) (:id |ByGoCGg_YCt-) (:text |cursor) (:by |root) (:at 1504774121421)
-                              |r $ {} (:type :leaf) (:id |HJQo0flOF0Fb) (:text |:data) (:by |root) (:at 1504774121421)
-                          |v $ {} (:type :leaf) (:id |B1NiAMxuK0Kb) (:text |next-state) (:by |root) (:at 1504774121421)
-        :proc $ {} (:type :expr) (:id |SJcYCzxOt0K-) (:by nil) (:at 1504774121421) (:data $ {})
       |respo.render.patch $ {}
         :ns $ {} (:type :expr) (:id |SkRBylzeOY0KZ) (:by nil) (:at 1504774121421)
           :data $ {}
@@ -6627,13 +6646,11 @@
                         |T $ {} (:type :leaf) (:id |ryDQmzeutAtZ) (:text |defcomp) (:by |root) (:at 1504774121421)
                         |vT $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1552321198978) (:text |textarea) (:id |Rpdee9TJIL)
                         |w $ {} (:type :leaf) (:text |<>) (:id |BkxT6GSB5b) (:by |root) (:at 1505215173770)
-                        |yr $ {} (:type :leaf) (:by |root) (:at 1515602643998) (:text |mutation->) (:id |S1gtCzT7NG)
                         |yT $ {} (:type :leaf) (:text |list->) (:id |H1eRhnFJCb) (:by |root) (:at 1509035192092)
                         |j $ {} (:type :leaf) (:id |BkOXQGeuYAYb) (:text |div) (:by |root) (:at 1504774121421)
                         |v $ {} (:type :leaf) (:id |Byc7QMe_tCFZ) (:text |input) (:by |root) (:at 1504774121421)
-                        |yj $ {} (:type :leaf) (:by |root) (:at 1515602640546) (:text |action->) (:id |S1b8Cfp7NG)
+                        |yx $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719016462) (:text |>>) (:id |b5eHL3B1H5)
                         |r $ {} (:type :leaf) (:id |H1YmQze_FRF-) (:text |span) (:by |root) (:at 1504774121421)
-                        |y $ {} (:type :leaf) (:id |r1h7mfgOKAKW) (:text |cursor->) (:by |root) (:at 1504774121421)
                         |D $ {} (:type :leaf) (:text |[]) (:id |Hyg5A04Bc-) (:by |root) (:at 1505214162915)
                         |yv $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571574481109) (:text |defeffect) (:id |1RboEANKc)
                 |yr $ {} (:type :expr) (:id |ryRUmMgOY0tZ) (:by nil) (:at 1504774121421)
@@ -6713,38 +6730,6 @@
                         |j $ {} (:type :leaf) (:id |SksP7flOK0Fb) (:text |text-width) (:by |rJoDgvdeG) (:at 1511713175666)
                         |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571935419517) (:text |time!) (:id |ABX3khSeTz)
         :defs $ {}
-          |handle-add $ {} (:type :expr) (:id |HyZY7flOFAtZ) (:by nil) (:at 1504774121421)
-            :data $ {}
-              |T $ {} (:type :leaf) (:id |ByGYQMl_FCtZ) (:text |defn) (:by |root) (:at 1504774121421)
-              |j $ {} (:type :leaf) (:id |B1XKmGlOFAF-) (:text |handle-add) (:by |root) (:at 1504774121421)
-              |r $ {} (:type :expr) (:id |r1NKmzldYAt-) (:by nil) (:at 1504774121421)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:id |BkrFXGldK0YW) (:text |state) (:by |root) (:at 1504774121421)
-              |v $ {} (:type :expr) (:id |SyUKmMx_tAYW) (:by nil) (:at 1504774121421)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:id |HkvY7GguKRYW) (:text |fn) (:by |root) (:at 1504774121421)
-                  |j $ {} (:type :expr) (:id |rkdKXfluYAt-) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |rJYFQMlOYAtb) (:text |e) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:id |H19KXGeOF0Fb) (:text |dispatch!) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :leaf) (:id |SystQGxuFAtZ) (:text |mutate!) (:by |root) (:at 1504774121421)
-                  |r $ {} (:type :expr) (:id |By3F7zxuKCt-) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |B1TY7GxuFAtb) (:text |dispatch!) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:id |SkAKXfx_FCF-) (:text |:add) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :expr) (:id |H1JqXGldK0KW) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:id |Hkg57GxdF0tb) (:text |:draft) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :leaf) (:id |Sy-9mfeOYAKW) (:text |state) (:by |root) (:at 1504774121421)
-                  |v $ {} (:type :expr) (:id |BkMqmfldKRKZ) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |SJX5XMx_YRK-) (:text |mutate!) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :expr) (:id |S1N5Xzx_t0tW) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:id |rJHq7zeOF0tb) (:text |assoc) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :leaf) (:id |BJI5XfgdtCtZ) (:text |state) (:by |root) (:at 1504774121421)
-                          |r $ {} (:type :leaf) (:id |rkDqQzgOF0YW) (:text |:draft) (:by |root) (:at 1504774121421)
-                          |v $ {} (:type :leaf) (:id |HJOcXMedtCFZ) (:text ||) (:by |root) (:at 1504774121421)
           |style-root $ {} (:type :expr) (:id |S1Yc7GgutRtZ) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:id |By9cQfgOtRKW) (:text |def) (:by |root) (:at 1504774121421)
@@ -7101,6 +7086,15 @@
                                   |T $ {} (:type :leaf) (:id |HJ5YVMldtRYZ) (:text |:data) (:by |root) (:at 1504774121421)
                                   |j $ {} (:type :leaf) (:id |HJsYNMedY0Fb) (:text |states) (:by |root) (:at 1504774121421)
                               |r $ {} (:type :leaf) (:id |HynYNzldYRYZ) (:text |initial-state) (:by |root) (:at 1504774121421)
+                      |D $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718933236)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718934262) (:text |cursor) (:id |yPhdU91iCleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718934490)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718936300) (:text |:cursor) (:id |BDEjdcb28y)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718936996) (:text |states) (:id |GuJkiGOlJD)
+                            :id |nBDoehdq1Z
+                        :id |yPhdU91iC
                   |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571574450097) (:id |u8cLCYV5i)
                     :data $ {}
                       |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571574450942) (:text |[]) (:id |LhMu5lA1zv)
@@ -7171,11 +7165,20 @@
                                       |v $ {} (:type :expr) (:id |rJ_grMxuYAtb) (:by nil) (:at 1504774121421)
                                         :data $ {}
                                           |j $ {} (:type :leaf) (:id |HycgSze_FRFW) (:text |:on-click) (:by |root) (:at 1513785859523)
-                                          |r $ {} (:type :expr) (:by |root) (:at 1515602317260) (:id |BklHcZpQ4f)
+                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719201804)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:id |H1ixHMldF0YZ) (:text |action->) (:by |root) (:at 1515602699160)
-                                              |j $ {} (:type :leaf) (:id |ryJtmfguFCFZ) (:text |:clear) (:by |root) (:at 1504774121421)
-                                              |r $ {} (:type :leaf) (:id |ryeYmGgOtRt-) (:text |nil) (:by |root) (:at 1504774121421)
+                                              |T $ {} (:type :expr) (:by |root) (:at 1515602317260) (:id |BklHcZpQ4f)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:id |H1ixHMldF0YZ) (:text |d!) (:by |rJoDgvdeG) (:at 1584719206363)
+                                                  |j $ {} (:type :leaf) (:id |ryJtmfguFCFZ) (:text |:clear) (:by |root) (:at 1504774121421)
+                                                  |r $ {} (:type :leaf) (:id |ryeYmGgOtRt-) (:text |nil) (:by |root) (:at 1504774121421)
+                                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719202433) (:text |fn) (:id |V2fU8jYzp)
+                                              |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719202698)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719202947) (:text |e) (:id |Kz43asRKbL)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719204094) (:text |d!) (:id |3SZ95MjxE9)
+                                                :id |Bt_nai5-Nn
+                                            :id |L6Kinpq8rZ
                               |j $ {} (:type :expr) (:id |ByCcVMedt0tZ) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:id |S11jEMe_FRKW) (:text |{}) (:by |root) (:at 1504774121421)
@@ -7194,10 +7197,37 @@
                                       |r $ {} (:type :expr) (:id |ByMsab_Gz) (:by nil) (:at 1504774121421)
                                         :data $ {}
                                           |j $ {} (:type :leaf) (:id |r111Hzx_FRKb) (:text |:on-click) (:by |root) (:at 1513786776154)
-                                          |r $ {} (:type :expr) (:id |BkgJHzguFAYZ) (:by nil) (:at 1504774121421)
+                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718972053)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:id |ByZkSGeuKRK-) (:text |handle-add) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :leaf) (:id |S1zyBfl_Y0YZ) (:text |state) (:by |root) (:at 1504774121421)
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |fn) (:id |9fL7h4nSQR)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718972053)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |e) (:id |3Kd4CeZi1z)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |d!) (:id |WK8DDhAwJt)
+                                                :id |ZNhmJctUkt
+                                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718972053)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |d!) (:id |Iu4UtwP5d7)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |:add) (:id |b-6dx68sKm)
+                                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718972053)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |:draft) (:id |WHTzzp4ehd)
+                                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |state) (:id |dHECc3PnRH)
+                                                    :id |UjI3BZQnwt
+                                                :id |DrUlIKqyab
+                                              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718972053)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |d!) (:id |EHrzewg6tB)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718976271) (:text |cursor) (:id |-sT9VYGc-l)
+                                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718972053)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |assoc) (:id |I37W2TjDwoF)
+                                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |state) (:id |HBMMyRcpuxO)
+                                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text |:draft) (:id |AIuJjd92AL4)
+                                                      |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718972053) (:text ||) (:id |HDmca2GJ2BY)
+                                                    :id |VEhWvK_ARl9
+                                                :id |w6U9b1eum2
+                                            :id |-H0uU7vYDj
                                   |r $ {} (:type :expr) (:id |S171SzxOF0t-) (:by nil) (:at 1504774121421)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:id |BkNyBfxdK0K-) (:text |span) (:by |root) (:at 1541907201738)
@@ -7272,18 +7302,28 @@
                                       |x $ {} (:type :expr) (:id |Hyd6EMe_YCF-) (:by nil) (:at 1504774121421)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:id |rkK6NGlOYCF-) (:text |:on-input) (:by |root) (:at 1513785840605)
-                                          |j $ {} (:type :expr) (:id |BJidQaXEG) (:by nil) (:at 1504774121421)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718917698)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:id |BJMPNMldtAYb) (:text |mutation->) (:by |root) (:at 1515602808095)
-                                              |j $ {} (:type :expr) (:id |BJXwEGeuYAKW) (:by nil) (:at 1504774121421)
+                                              |T $ {} (:type :expr) (:id |BJidQaXEG) (:by nil) (:at 1504774121421)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:id |HkNwVfgutCtW) (:text |assoc) (:by |root) (:at 1504774121421)
-                                                  |j $ {} (:type :leaf) (:id |HJHDVflOKCFZ) (:text |state) (:by |root) (:at 1504774121421)
-                                                  |r $ {} (:type :leaf) (:id |Bk8PEzgdtCt-) (:text |:draft) (:by |root) (:at 1504774121421)
-                                                  |v $ {} (:type :expr) (:id |SJDvNfgOFAY-) (:by nil) (:at 1504774121421)
+                                                  |T $ {} (:type :leaf) (:id |BJMPNMldtAYb) (:text |d!) (:by |rJoDgvdeG) (:at 1584718922663)
+                                                  |j $ {} (:type :expr) (:id |BJXwEGeuYAKW) (:by nil) (:at 1504774121421)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:id |SJdvVMeuFRYW) (:text |:value) (:by |root) (:at 1504774121421)
-                                                      |j $ {} (:type :leaf) (:id |H1FPEGldY0KZ) (:text |%e) (:by |root) (:at 1515603012708)
+                                                      |T $ {} (:type :leaf) (:id |HkNwVfgutCtW) (:text |assoc) (:by |root) (:at 1504774121421)
+                                                      |j $ {} (:type :leaf) (:id |HJHDVflOKCFZ) (:text |state) (:by |root) (:at 1504774121421)
+                                                      |r $ {} (:type :leaf) (:id |Bk8PEzgdtCt-) (:text |:draft) (:by |root) (:at 1504774121421)
+                                                      |v $ {} (:type :expr) (:id |SJDvNfgOFAY-) (:by nil) (:at 1504774121421)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:id |SJdvVMeuFRYW) (:text |:value) (:by |root) (:at 1504774121421)
+                                                          |j $ {} (:type :leaf) (:id |H1FPEGldY0KZ) (:text |e) (:by |rJoDgvdeG) (:at 1584719194955)
+                                                  |b $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718940793) (:text |cursor) (:id |EWD6KYzRpe)
+                                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718918282) (:text |fn) (:id |fOQI7syXIK)
+                                              |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718918562)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718918864) (:text |e) (:id |0XUboZH1sJ)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718919959) (:text |d!) (:id |AHp2dLXif)
+                                                :id |CRyk1PEqez
+                                            :id |3oXW1gsvml
                                       |y $ {} (:type :expr) (:id |r1664fl_FRK-) (:by nil) (:at 1504774121421)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:id |SyAaNzl_KAYb) (:text |:on-focus) (:by |root) (:at 1513785843651)
@@ -7341,11 +7381,14 @@
                                                   |j $ {} (:type :leaf) (:id |rkINBflOKAtZ) (:text |task-id) (:by |root) (:at 1504774121421)
                                                   |r $ {} (:type :expr) (:id |HyPErfeOYRFb) (:by nil) (:at 1504774121421)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:id |rJd4SGgOFCtZ) (:text |cursor->) (:by |root) (:at 1504774121421)
-                                                      |j $ {} (:type :leaf) (:id |HytEBfg_FCtZ) (:text |task-id) (:by |root) (:at 1504774121421)
                                                       |r $ {} (:type :leaf) (:id |Hy5VHGldKRFZ) (:text |comp-task) (:by |root) (:at 1515603002223)
-                                                      |v $ {} (:type :leaf) (:id |HkoESfxdFCFb) (:text |states) (:by |root) (:at 1504774121421)
                                                       |x $ {} (:type :leaf) (:id |r1hNHfeuF0K-) (:text |task) (:by |root) (:at 1504774121421)
+                                                      |t $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718760523)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718761557) (:text |>>) (:id |C3I30l8ua)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718762077) (:text |task-id) (:id |m_HrH1eWWk)
+                                                          |b $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718766713) (:text |states) (:id |JKVm9SFOi)
+                                                        :id |izH2skvPX
                           |y $ {} (:type :expr) (:id |HJaVrzluKCYW) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |r1RErGxdKCtb) (:text |if) (:by |root) (:at 1504774121421)
@@ -7383,7 +7426,7 @@
                                               |j $ {} (:type :leaf) (:id |r1B8BMlutRtZ) (:text |widget/button) (:by |root) (:at 1504774121421)
                                           |r $ {} (:type :expr) (:id |rk8LHzxOK0tb) (:by nil) (:at 1504774121421)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:id |rkwIBzgdtCKb) (:text |:on) (:by |root) (:at 1504774121421)
+                                              |T $ {} (:type :leaf) (:id |rkwIBzgdtCKb) (:text |:on-click) (:by |rJoDgvdeG) (:at 1584719033076)
                                               |j $ {} (:type :expr) (:id |HkOIBGeOYRFW) (:by nil) (:at 1504774121421)
                                                 :data $ {}
                                                   |T $ {} (:type :leaf) (:id |SktUHGeuFCF-) (:text |if) (:by |root) (:at 1504774121421)
@@ -7391,20 +7434,21 @@
                                                     :data $ {}
                                                       |T $ {} (:type :leaf) (:id |ByoUBGguYCKZ) (:text |:locked?) (:by |root) (:at 1504774121421)
                                                       |j $ {} (:type :leaf) (:id |r12ISzedFCYW) (:text |state) (:by |root) (:at 1504774121421)
-                                                  |r $ {} (:type :expr) (:id |r1pLSfgut0KW) (:by nil) (:at 1504774121421)
+                                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719039343)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:id |B1RISzlOYAF-) (:text |{}) (:by |root) (:at 1504774121421)
-                                                  |v $ {} (:type :expr) (:id |By1DHzg_tRKZ) (:by nil) (:at 1504774121421)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:id |HJePrflutCtb) (:text |{}) (:by |root) (:at 1504774121421)
-                                                      |j $ {} (:type :expr) (:by |root) (:at 1515602497876) (:id |r1gqSGaXVM)
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719039343) (:text |fn) (:id |FYXmhy2PYY)
+                                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719039343)
                                                         :data $ {}
-                                                          |T $ {} (:type :leaf) (:id |HJWDSzxdKCtZ) (:text |:click) (:by |root) (:at 1504774121421)
-                                                          |j $ {} (:type :expr) (:by |root) (:at 1515602501120) (:id |BkepHf6QVz)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |root) (:at 1515602626227) (:text |action->) (:id |BJiHfaXVM)
-                                                              |j $ {} (:type :leaf) (:by |root) (:at 1515602503574) (:text |:clear) (:id |HyRrMpQNM)
-                                                              |r $ {} (:type :leaf) (:by |root) (:at 1515602504194) (:text |nil) (:id |rkeg8zaQVf)
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719039343) (:text |e) (:id |h9KAmdhSp1)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719039343) (:text |d!) (:id |DjD6Omut3A)
+                                                        :id |hDwONZWB7r
+                                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719039343)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719039343) (:text |d!) (:id |G-rNmTcbmt)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719039343) (:text |:clear) (:id |75kyxT-kw9)
+                                                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719039343) (:text |nil) (:id |MUkquubAqn)
+                                                        :id |3IxdE2TCW6
+                                                    :id |Xdk4BQFbmS
                                       |r $ {} (:type :expr) (:id |ryQwrzlOK0Y-) (:by nil) (:at 1504774121421)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:id |rJ4vHMeOYRFZ) (:text |<>) (:by |root) (:at 1504774121421)
@@ -7427,15 +7471,25 @@
                                           |r $ {} (:type :expr) (:id |B1iX5ZdMz) (:by nil) (:at 1504774121421)
                                             :data $ {}
                                               |j $ {} (:type :leaf) (:id |ryPdrGxOtRYb) (:text |:on-click) (:by |root) (:at 1513785889595)
-                                              |r $ {} (:type :expr) (:id |S1keGpXEf) (:by nil) (:at 1504774121421)
+                                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718996844)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:id |SyIdNGeOKRtb) (:text |mutation->) (:by |root) (:at 1515602629517)
-                                                  |j $ {} (:type :expr) (:id |B1wuVfldKRYb) (:by nil) (:at 1504774121421)
+                                                  |T $ {} (:type :expr) (:id |S1keGpXEf) (:by nil) (:at 1504774121421)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:id |HyuOVGluYAtW) (:text |update) (:by |root) (:at 1504774121421)
-                                                      |j $ {} (:type :leaf) (:id |BkYd4GlOYCY-) (:text |state) (:by |root) (:at 1504774121421)
-                                                      |r $ {} (:type :leaf) (:id |S1quEzgOYCKW) (:text |:locked?) (:by |root) (:at 1504774121421)
-                                                      |v $ {} (:type :leaf) (:id |SksuVzxOFCFW) (:text |not) (:by |root) (:at 1504774121421)
+                                                      |T $ {} (:type :leaf) (:id |SyIdNGeOKRtb) (:text |d!) (:by |rJoDgvdeG) (:at 1584719000658)
+                                                      |j $ {} (:type :expr) (:id |B1wuVfldKRYb) (:by nil) (:at 1504774121421)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:id |HyuOVGluYAtW) (:text |update) (:by |root) (:at 1504774121421)
+                                                          |j $ {} (:type :leaf) (:id |BkYd4GlOYCY-) (:text |state) (:by |root) (:at 1504774121421)
+                                                          |r $ {} (:type :leaf) (:id |S1quEzgOYCKW) (:text |:locked?) (:by |root) (:at 1504774121421)
+                                                          |v $ {} (:type :leaf) (:id |SksuVzxOFCFW) (:text |not) (:by |root) (:at 1504774121421)
+                                                      |b $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719001619) (:text |cursor) (:id |SB5IuKH1XN)
+                                                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718997374) (:text |fn) (:id |SD4KkmaTV)
+                                                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718997610)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718997836) (:text |e) (:id |BlTsHK7WJ-)
+                                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718998626) (:text |d!) (:id |NPS8sQfum)
+                                                    :id |Q6MwVS5eEr
+                                                :id |fHaBC4nxsC
                                       |r $ {} (:type :expr) (:id |rJodHGx_tRFb) (:by nil) (:at 1504774121421)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:id |r12OrzeuKCK-) (:text |<>) (:by |root) (:at 1504774121421)
@@ -7853,12 +7907,10 @@
                     |v $ {} (:type :expr) (:id |BySnSzxutRFZ) (:by nil) (:at 1504774121421)
                       :data $ {}
                         |T $ {} (:type :leaf) (:id |By8nSfluKCKb) (:text |[]) (:by |root) (:at 1504774121421)
-                        |yr $ {} (:type :leaf) (:by |root) (:at 1515603099176) (:text |mutation->) (:id |SJ-oVTm4G)
                         |yT $ {} (:type :leaf) (:id |S13hHGlutCt-) (:text |<>) (:by |root) (:at 1504774121421)
                         |j $ {} (:type :leaf) (:id |BkPhSfedFAFZ) (:text |defcomp) (:by |root) (:at 1504774121421)
                         |x $ {} (:type :leaf) (:id |Hk5hBzeOtCF-) (:text |span) (:by |root) (:at 1504774121421)
                         |v $ {} (:type :leaf) (:id |HyFnBfgdKRtb) (:text |input) (:by |root) (:at 1504774121421)
-                        |yj $ {} (:type :leaf) (:by |root) (:at 1515602886484) (:text |action->) (:id |ByTT7Tm4G)
                         |r $ {} (:type :leaf) (:id |S1_2HzguYRtW) (:text |div) (:by |root) (:at 1504774121421)
                         |y $ {} (:type :leaf) (:id |Hyihrzl_t0Y-) (:text |button) (:by |root) (:at 1504774121421)
                         |yv $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571586991762) (:text |defeffect) (:id |IRJTV7Y7qm)
@@ -7920,6 +7972,15 @@
                                   |T $ {} (:type :leaf) (:id |rJqmLGxuKCF-) (:text |:data) (:by |root) (:at 1504774121421)
                                   |j $ {} (:type :leaf) (:id |S1jXLfeuFRFb) (:text |states) (:by |root) (:at 1504774121421)
                               |r $ {} (:type :leaf) (:id |Hk3mIfxutRtZ) (:text ||) (:by |root) (:at 1504774121421)
+                      |D $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719172690)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719173865) (:text |cursor) (:id |3IxCp0ECIyleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719174123)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719176906) (:text |:cursor) (:id |_KYMlB4yti)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719177962) (:text |states) (:id |ZnNGft0PXE)
+                            :id |peCMoVqb1
+                        :id |3IxCp0ECIy
                   |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571586889509) (:id |vSqJPi1R6Z)
                     :data $ {}
                       |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571586890799) (:text |[]) (:id |bJdz2REVP)
@@ -7993,14 +8054,23 @@
                                   |r $ {} (:type :expr) (:id |Hy-Pr9-uMG) (:by nil) (:at 1504774121421)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:id |BJRIUGx_tAFW) (:text |:on-click) (:by |root) (:at 1513785917865)
-                                      |r $ {} (:type :expr) (:id |r1727aQ4f) (:by nil) (:at 1504774121421)
+                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719149495)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:id |SJrb8MeOK0YZ) (:text |action->) (:by |root) (:at 1515602869161)
-                                          |j $ {} (:type :leaf) (:id |BkIZ8GeOFCF-) (:text |:toggle) (:by |root) (:at 1504774121421)
-                                          |r $ {} (:type :expr) (:id |H1DnmTX4M) (:by nil) (:at 1504774121421)
+                                          |T $ {} (:type :expr) (:id |r1727aQ4f) (:by nil) (:at 1504774121421)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:id |BJzDUfxOFRFZ) (:text |:id) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :leaf) (:id |rJ7vIMgdFRFW) (:text |task) (:by |root) (:at 1504774121421)
+                                              |T $ {} (:type :leaf) (:id |SJrb8MeOK0YZ) (:text |d!) (:by |rJoDgvdeG) (:at 1584719153664)
+                                              |j $ {} (:type :leaf) (:id |BkIZ8GeOFCF-) (:text |:toggle) (:by |root) (:at 1504774121421)
+                                              |r $ {} (:type :expr) (:id |H1DnmTX4M) (:by nil) (:at 1504774121421)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:id |BJzDUfxOFRFZ) (:text |:id) (:by |root) (:at 1504774121421)
+                                                  |j $ {} (:type :leaf) (:id |rJ7vIMgdFRFW) (:text |task) (:by |root) (:at 1504774121421)
+                                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719150633) (:text |fn) (:id |3dcXWCq607)
+                                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719150856)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719151115) (:text |e) (:id |fxZVqozUv5)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719151808) (:text |d!) (:id |LY32MbSfyU)
+                                            :id |dvblkjs4ks
+                                        :id |a-2WY0OWZe
                           |yj $ {} (:type :expr) (:id |HyeKLfeOFAKW) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |rkbFUzeuFAK-) (:text |input) (:by |root) (:at 1504774121421)
@@ -8018,13 +8088,25 @@
                                   |v $ {} (:type :expr) (:id |BkTFaZdMM) (:by nil) (:at 1504774121421)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:id |r11c8Ggut0tb) (:text |:on-input) (:by |root) (:at 1513786754951)
-                                      |j $ {} (:type :expr) (:id |HJhFET7Ef) (:by nil) (:at 1504774121421)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719089367)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:id |HJ01wGguFCKb) (:text |mutation->) (:by |root) (:at 1515603079542)
-                                          |j $ {} (:type :expr) (:id |BJklPMx_YCYZ) (:by nil) (:at 1504774121421)
+                                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719090017) (:text |fn) (:id |Qr4TEofhKP)
+                                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719090626)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:id |S1exvzgOFRKZ) (:text |:value) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :leaf) (:id |S1bxwfldYAt-) (:text |%e) (:by |root) (:at 1515603082544)
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719090845) (:text |e) (:id |whclOrvyq)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719091699) (:text |d!) (:id |ZJ-H0rcpaE)
+                                            :id |iuZFwI1l6I
+                                          |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719094021)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719094932) (:text |d!) (:id |UpjsAm6V8mleaf)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719096043) (:text |cursor) (:id |NhtWUx8yg)
+                                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719097135)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719097786) (:text |:value) (:id |DMkhcYEbR)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720105188) (:text |e) (:id |XwiqieVDLb)
+                                                :id |qAVY-IjbH
+                                            :id |UpjsAm6V8m
+                                        :id |R_2NVK0w2D
                           |yx $ {} (:type :expr) (:id |ByYoUGeuFAKb) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |BJcjUfldKRYW) (:text |=<) (:by |root) (:at 1504774121421)
@@ -8062,10 +8144,59 @@
                                   |v $ {} (:type :expr) (:id |H1lmHc-uzM) (:by |root) (:at 1505382679150)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:id |H1_u8zlutCKb) (:text |:on-input) (:by |root) (:at 1513785912794)
-                                      |j $ {} (:type :expr) (:id |BJxe7b0wcW) (:by nil) (:at 1504774121421)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:id |Hk9u8fluFCFZ) (:text |on-text-change) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |rkjOLfgdYCKW) (:text |task) (:by |root) (:at 1504774121421)
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |fn) (:id |D-cOSOTg-i)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719163429) (:text |e) (:id |qNQsuhPizY)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719164292) (:text |d!) (:id |BK-kb9gv29)
+                                            :id |AWCbJmBi2C
+                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |let) (:id |i2NPMzB0jZ)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                                :data $ {}
+                                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |task-id) (:id |aSeSemG0yr)
+                                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |:id) (:id |c2u6rQ1M2a)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |task) (:id |RiSnx91wQ7)
+                                                        :id |zO1EqQVGYi
+                                                    :id |PL-IVUq44l
+                                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |text) (:id |F9ofj_mQoCN)
+                                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |:value) (:id |xkrxIeqK4WX)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719160982) (:text |e) (:id |rnDHbxnHkEG)
+                                                        :id |sGLA1uXv5oZ
+                                                    :id |OgX-fY3txPS
+                                                :id |NzDa4Qzuff
+                                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719134707) (:text |d!) (:id |9sNRZ3MZn3R)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |:update) (:id |918jaCaHspX)
+                                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719138745)
+                                                    :data $ {}
+                                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719129318)
+                                                        :data $ {}
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |:id) (:id |Dayoyck_VCa)
+                                                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719129318) (:text |task-id) (:id |pkIB67qsLBg)
+                                                        :id |PavuGX2H4XY
+                                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719139337) (:text |{}) (:id |9nfhPA140X)
+                                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719141429)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719142464) (:text |:text) (:id |PvSC1YhUcleaf)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719143230) (:text |text) (:id |fduRUOj6w4)
+                                                        :id |PvSC1YhUc
+                                                    :id |67cmYenMDQ
+                                                :id |cPORqhp7tuJ
+                                            :id |go1iH3sA6Z
+                                        :id |hfY-nk8bOJ
                           |yy $ {} (:type :expr) (:id |HJpjIGxOFAFb) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |BJRjLMgutRFW) (:text |div) (:by |root) (:at 1504774121421)
@@ -8089,14 +8220,23 @@
                                   |r $ {} (:type :expr) (:by |root) (:at 1515603131600) (:id |S1EpEaQVz)
                                     :data $ {}
                                       |D $ {} (:type :leaf) (:by |root) (:at 1515603136628) (:text |:on-click) (:id |rJl4aVpQ4z)
-                                      |T $ {} (:type :expr) (:id |rksnEpX4G) (:by nil) (:at 1504774121421)
+                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719102767)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:id |rJWyDMxdKAKb) (:text |action->) (:by |root) (:at 1515603120569)
-                                          |j $ {} (:type :leaf) (:id |HkGkwGlOFRtW) (:text |:remove) (:by |root) (:at 1504774121421)
-                                          |r $ {} (:type :expr) (:id |HyQkPzeOYAF-) (:by nil) (:at 1504774121421)
+                                          |T $ {} (:type :expr) (:id |rksnEpX4G) (:by nil) (:at 1504774121421)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:id |ByEJDGxutAYW) (:text |:id) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :leaf) (:id |ryrJvGlOFRYZ) (:text |task) (:by |root) (:at 1504774121421)
+                                              |T $ {} (:type :leaf) (:id |rJWyDMxdKAKb) (:text |d!) (:by |rJoDgvdeG) (:at 1584719108258)
+                                              |j $ {} (:type :leaf) (:id |HkGkwGlOFRtW) (:text |:remove) (:by |root) (:at 1504774121421)
+                                              |r $ {} (:type :expr) (:id |HyQkPzeOYAF-) (:by nil) (:at 1504774121421)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:id |ByEJDGxutAYW) (:text |:id) (:by |root) (:at 1504774121421)
+                                                  |j $ {} (:type :leaf) (:id |ryrJvGlOFRYZ) (:text |task) (:by |root) (:at 1504774121421)
+                                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719103368) (:text |fn) (:id |CHlNo2xzpy)
+                                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719103687)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719103914) (:text |e) (:id |Zp68cHjbNU)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719104519) (:text |d!) (:id |HG5_q2OrKt)
+                                            :id |BwbNEcxC4W
+                                        :id |5sRzwSaUW9
                               |r $ {} (:type :expr) (:id |Bk4iIze_FRKb) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:id |ryBsLMe_KRtW) (:text |<>) (:by |root) (:at 1504774121421)
@@ -8120,6 +8260,7 @@
                   |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571586977512) (:text "|\"Task effect") (:id |Nh9WQ__ZiX)
                   |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571586982894) (:text |action) (:id |QUHWtf6PI)
                   |y $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572885427880) (:text |at-place?) (:id |oU7eBqMYH)
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720137605) (:text |;) (:id |a3FejHCBE)
               |yT $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572086688548) (:id |s1_FfiTku)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086689200) (:text |case) (:id |s1_FfiTkuleaf)
@@ -8150,6 +8291,7 @@
                               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086744295) (:text |println) (:id |WNPFvKs6KQleaf)
                               |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086747755) (:text "|\"Stored") (:id |FDiWf90tD)
                               |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086749463) (:text |x0) (:id |XzmGbDjIFl)
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720182535) (:text |;) (:id |85GwMltfG)
                   |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572086750609) (:id |Grnei3h8l)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086751544) (:text |:update) (:id |Grnei3h8lleaf)
@@ -8162,18 +8304,20 @@
                               |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086762623) (:text |get) (:id |6fUEY87oPi)
                               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086760313) (:text |@*local) (:id |rjQcJzSRFx)
                               |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086764450) (:text |:data) (:id |MMauXkHvO)
+                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720178072) (:text |;) (:id |3baOOP3no)
                   |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572086765428) (:id |yNdwuiDahS)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086766906) (:text |:unmount) (:id |yNdwuiDahSleaf)
                       |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572086770977) (:id |dRIqH-wgbO)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086770977) (:text |println) (:id |iZcPC4fay0)
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720180308) (:text |println) (:id |iZcPC4fay0)
                           |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086770977) (:text "|\"read") (:id |_sNU8v-p0P)
                           |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572086770977) (:id |T6cDTdYLCr)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086770977) (:text |get) (:id |cDjq5ZVfux)
                               |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086770977) (:text |@*local) (:id |utLfoUdm3k)
                               |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086770977) (:text |:data) (:id |7wVP6sX-AD)
+                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720180800) (:text |;) (:id |CaDq9HsTfL)
                   |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572086772386) (:id |bu5vXOJBV3)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086772701) (:text |do) (:id |bu5vXOJBV3leaf)
@@ -8196,51 +8340,6 @@
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |r1dlIfedFAK-) (:text |println) (:by |root) (:at 1504774121421)
                       |j $ {} (:type :leaf) (:id |BkYlUGlutAKZ) (:text ||clicked.) (:by |root) (:at 1504774121421)
-          |on-text-change $ {} (:type :expr) (:id |HkInIfeOYCKW) (:by nil) (:at 1504774121421)
-            :data $ {}
-              |T $ {} (:type :leaf) (:id |HyvnLfxOKCY-) (:text |defn) (:by |root) (:at 1504774121421)
-              |j $ {} (:type :leaf) (:id |SyO3IMeOFCKb) (:text |on-text-change) (:by |root) (:at 1504774121421)
-              |r $ {} (:type :expr) (:id |SkYnUfxuKAYZ) (:by nil) (:at 1504774121421)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:id |Hk53IMxdKRFW) (:text |task) (:by |root) (:at 1504774121421)
-              |v $ {} (:type :expr) (:id |BJo2IGx_KRFZ) (:by nil) (:at 1504774121421)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:id |S1n3IfgutRF-) (:text |fn) (:by |root) (:at 1504774121421)
-                  |j $ {} (:type :expr) (:id |rJp2LGeuY0Y-) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |Sk0nIGgdtAYW) (:text |event) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:id |rkkpUzxdtAKZ) (:text |dispatch!) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :leaf) (:by |root) (:at 1515731343882) (:text |mutate!) (:id |ryv9KhHVz)
-                  |r $ {} (:type :expr) (:id |BJeaUfxdFRF-) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |ry-6Izx_KRYb) (:text |let) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :expr) (:id |Hyfa8GxuYAKZ) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :expr) (:id |S1X6IfeuYCFb) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |Bk4pIMgOYAY-) (:text |task-id) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:id |HkSpUfgutAYb) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |Bk86LzxOKRtZ) (:text |:id) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :leaf) (:id |rkPaLfgdF0KW) (:text |task) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :expr) (:id |SJuTLzxdFAFb) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |SkKTUMg_K0t-) (:text |text) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:id |Bk5p8zx_FRKW) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |H1oTUMxutRFW) (:text |:value) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :leaf) (:id |rJ2TUMxOYRtZ) (:text |event) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :expr) (:id |ry6p8fgdtCKb) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:id |S10TIMgdFCKb) (:text |dispatch!) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :leaf) (:id |SJJCIze_tCKW) (:text |:update) (:by |root) (:at 1504774121421)
-                          |r $ {} (:type :expr) (:id |rJxRLfgdt0K-) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |B1-ALzluYRY-) (:text |{}) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :leaf) (:id |H1f0UfxdKAYW) (:text |:id) (:by |root) (:at 1504774121421)
-                              |r $ {} (:type :leaf) (:id |rkm0LfgdFRtZ) (:text |task-id) (:by |root) (:at 1504774121421)
-                              |v $ {} (:type :leaf) (:id |Hk4CIMxuKAFZ) (:text |:text) (:by |root) (:at 1504774121421)
-                              |x $ {} (:type :leaf) (:id |SkBCUfe_F0tZ) (:text |text) (:by |root) (:at 1504774121421)
           |style-done $ {} (:type :expr) (:id |HJd-UzeuKCKW) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:id |HktZUfxdtRFb) (:text |def) (:by |root) (:at 1504774121421)
@@ -8499,10 +8598,6 @@
                       |j $ {} (:type :expr) (:id |BJetSeMluF0KW) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:id |H1bYBgMe_YRFW) (:text |[]) (:by |root) (:at 1504774121421)
-                  |yj $ {} (:type :expr) (:id |SysKHeGedtRt-) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |HJnFHxMluYRYb) (:text |:cursor) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:id |Hy6YHgGguKRt-) (:text |nil) (:by |root) (:at 1504774121421)
                   |r $ {} (:type :expr) (:id |BksdHeGeOtCFZ) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |rJ3OBlMlOKCYW) (:text |:coord) (:by |root) (:at 1504774121421)
@@ -8940,21 +9035,6 @@
                                   |j $ {} (:type :leaf) (:id |r1oNfGxdK0tb) (:text |@*global-element) (:by |root) (:at 1504774121421)
                                   |r $ {} (:type :leaf) (:id |Bk3EGfe_F0K-) (:text |coord) (:by |root) (:at 1504774121421)
                                   |v $ {} (:type :leaf) (:id |BkTVGMx_FRFZ) (:text |event-name) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :expr) (:id |Hy0Vzzl_tAYW) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |HkyHzGxuF0Yb) (:text |target-component) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:id |ByxHGzgOtAY-) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |B1bSzfe_K0tW) (:text |get-component-at) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :leaf) (:id |S1zHzzx_YRYb) (:text |@*global-element) (:by |root) (:at 1504774121421)
-                                  |r $ {} (:type :leaf) (:id |ByXrffedYAtb) (:text |coord) (:by |root) (:at 1504774121421)
-                          |r $ {} (:type :expr) (:id |HyVSfMeOKCt-) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |SJBrfzgdK0tZ) (:text |this-cursor) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:id |SkIHzzgOYAKb) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |rkDSGzgut0Yb) (:text |:cursor) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :leaf) (:id |rJ_HfMx_K0FZ) (:text |target-component) (:by |root) (:at 1504774121421)
                           |v $ {} (:type :expr) (:id |rJYrfzeOt0F-) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |HJ9rffguY0tZ) (:text |target-listener) (:by |root) (:at 1504774121421)
@@ -8966,53 +9046,6 @@
                                       |T $ {} (:type :leaf) (:id |HkCBGGgOF0tZ) (:text |:event) (:by |root) (:at 1504774121421)
                                       |j $ {} (:type :leaf) (:id |H11UMMxdK0F-) (:text |target-element) (:by |root) (:at 1504774121421)
                                   |r $ {} (:type :leaf) (:id |ByeLzGldt0K-) (:text |event-name) (:by |root) (:at 1504774121421)
-                          |x $ {} (:type :expr) (:id |SJWUffxOYAtZ) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |B1GIfMgOt0Yb) (:text |mutate!) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:id |ryX8zGxOFAK-) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |Sy4IfMgOFRK-) (:text |fn$) (:by |rJoDgvdeG) (:at 1513612020835)
-                                  |j $ {} (:type :expr) (:id |rkHUfMxOYAYb) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :expr) (:id |BJUUGMg_F0tZ) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |Hyw8GzeOK0FW) (:text |next-state) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :expr) (:id |Bk_IfMguYCtZ) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |SkKIzGxuYRYb) (:text |dispatch!) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |B1cIfMeOtRFb) (:text |:states) (:by |root) (:at 1504774121421)
-                                          |r $ {} (:type :expr) (:id |BksLzMe_KCKb) (:by nil) (:at 1504774121421)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:id |S1n8GGluFAFW) (:text |[]) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :leaf) (:id |S1a8Mfl_FAtb) (:text |this-cursor) (:by |root) (:at 1504774121421)
-                                              |r $ {} (:type :leaf) (:id |BkALzfxuFRK-) (:text |next-state) (:by |root) (:at 1504774121421)
-                                  |r $ {} (:type :expr) (:id |ByJwGfl_KRtb) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :expr) (:id |rkgDGfxOYRt-) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |SybDMMxuYAKW) (:text |cursor) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |BJGPzfgutAtb) (:text |next-state) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :expr) (:id |rkQPzGxdKAKZ) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |H1VPMzeuFAYZ) (:text |dispatch!) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |S1rPfMl_FCFW) (:text |:states) (:by |root) (:at 1504774121421)
-                                          |r $ {} (:type :expr) (:id |r1Lvfzedt0YZ) (:by nil) (:at 1504774121421)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:id |SkwvGMxuFRK-) (:text |[]) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :leaf) (:id |BJdwMzxOF0t-) (:text |cursor) (:by |root) (:at 1504774121421)
-                                              |r $ {} (:type :leaf) (:id |ByKDMMguKRtW) (:text |next-state) (:by |root) (:at 1504774121421)
-                      |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1554636352608) (:id |mBpDgn8qR)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1554636353057) (:text |if) (:id |mBpDgn8qRleaf)
-                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1554636353294) (:id |5FZlQv-rfd)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1554636354022) (:text |nil?) (:id |7kux86VmuC)
-                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1554636361360) (:text |target-component) (:id |BeXr7vtlZy)
-                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1554636362388) (:id |2cB59xrbe8)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1554636363397) (:text |println) (:id |2cB59xrbe8leaf)
-                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1554636398735) (:text "|\"Found no component for:") (:id |QVNY1eGaCz)
-                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1554636375123) (:text |coord) (:id |JmJ1RlNdw)
                       |r $ {} (:type :expr) (:id |HkqvzMgdKAFW) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:id |r1jwffxdKRF-) (:text |if) (:by |root) (:at 1504774121421)
@@ -9035,7 +9068,6 @@
                                   |T $ {} (:type :leaf) (:id |r1u_MMxdKAYZ) (:text |target-listener) (:by |root) (:at 1504774121421)
                                   |j $ {} (:type :leaf) (:id |SyKuMGg_t0K-) (:text |simple-event) (:by |root) (:at 1504774121421)
                                   |r $ {} (:type :leaf) (:id |By5dGfe_YAF-) (:text |dispatch!) (:by |root) (:at 1504774121421)
-                                  |v $ {} (:type :leaf) (:id |rysdffguKAtZ) (:text |mutate!) (:by |root) (:at 1504774121421)
                           |v $ {} (:type :expr) (:id |Hk2uMzluK0KW) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |Hy6_zGxOY0t-) (:text |;) (:by |root) (:at 1504774121421)
@@ -9134,130 +9166,6 @@
                                           |r $ {} (:type :leaf) (:id |ry5o-fx_tAKW) (:text |1) (:by |root) (:at 1504774121421)
                                   |v $ {} (:type :leaf) (:id |ByijZfxuFAFZ) (:text |event-name) (:by |root) (:at 1504774121421)
                               |v $ {} (:type :leaf) (:id |Sy2iZGluFCF-) (:text |nil) (:by |root) (:at 1504774121421)
-          |get-component-at $ {} (:type :expr) (:id |S1ZGZMeutAF-) (:by nil) (:at 1504774121421)
-            :data $ {}
-              |T $ {} (:type :leaf) (:id |SJGMbGldFCKZ) (:text |defn$) (:by |rJoDgvdeG) (:at 1513612003813)
-              |j $ {} (:type :leaf) (:id |H1mMWMedKAFb) (:text |get-component-at) (:by |root) (:at 1504774121421)
-              |r $ {} (:type :expr) (:id |ry4z-MluYCt-) (:by nil) (:at 1504774121421)
-                :data $ {}
-                  |T $ {} (:type :expr) (:id |r1HzbGgOFAYZ) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |rJUGbzl_Y0K-) (:text |markup) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:id |rJwz-MxuFAF-) (:text |coord) (:by |root) (:at 1504774121421)
-                  |j $ {} (:type :expr) (:id |Hy_GbfeuYRFb) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |SJYM-Gg_F0tb) (:text |get-component-at) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:id |Sy5zWMedtRtW) (:text |nil) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :leaf) (:id |r1izWfldY0FW) (:text |markup) (:by |root) (:at 1504774121421)
-                      |v $ {} (:type :leaf) (:id |S1nfbzxuK0YZ) (:text |coord) (:by |root) (:at 1504774121421)
-              |v $ {} (:type :expr) (:id |B1TG-Me_t0Y-) (:by nil) (:at 1504774121421)
-                :data $ {}
-                  |T $ {} (:type :expr) (:id |rkCfWGl_tCtb) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |rkkXWGe_YCFb) (:text |acc) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:id |Hyg7ZMgdKAtZ) (:text |markup) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :leaf) (:id |H1bmWMl_tRKW) (:text |coord) (:by |root) (:at 1504774121421)
-                  |j $ {} (:type :expr) (:id |Bkz7bGedYRt-) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |rkXXZGgutAKZ) (:text |if) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :expr) (:id |SJNmbfe_FCKW) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:id |rkH7-fxOtCY-) (:text |empty?) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :leaf) (:id |rk8XZGxOFCF-) (:text |coord) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :leaf) (:id |H1P7-Mx_FAKb) (:text |acc) (:by |root) (:at 1504774121421)
-                      |v $ {} (:type :expr) (:id |H1dQWzxuYAKb) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:id |SkF7-zxuFRtZ) (:text |let) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :expr) (:id |r1q7bMe_FAKW) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :expr) (:id |Syj7WGgdYRFW) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |HJ2QZGldYRKW) (:text |coord-head) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :expr) (:id |Syp7ZzeOFCF-) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:id |HJRQ-MedFCKb) (:text |first) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :leaf) (:id |r11NZzl_Y0F-) (:text |coord) (:by |root) (:at 1504774121421)
-                          |r $ {} (:type :expr) (:id |r1eEWzxuFRKb) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |BkWEbMldKCtZ) (:text |if) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:id |rJG4-feOtRFb) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |rkQN-Mx_K0KW) (:text |component?) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :leaf) (:id |B1N4WGxuK0FW) (:text |markup) (:by |root) (:at 1504774121421)
-                              |r $ {} (:type :expr) (:id |HkBNZMldKAFZ) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |BJ8NWzxdYRYW) (:text |if) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :expr) (:id |rkD4ZzeOYAF-) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:id |HJu4bMeOKAFb) (:text |=) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :expr) (:id |BkKNZGguYRFW) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |H1cN-zg_tRtb) (:text |:name) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |B1iEbGg_FRKW) (:text |markup) (:by |root) (:at 1504774121421)
-                                      |r $ {} (:type :leaf) (:id |SJ2V-MedKCFW) (:text |coord-head) (:by |root) (:at 1504774121421)
-                                  |r $ {} (:type :expr) (:id |ByaVbMgOt0tb) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:id |H1C4ZMx_t0Fb) (:text |recur) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :leaf) (:id |B11HZzlOtAtW) (:text |markup) (:by |root) (:at 1504774121421)
-                                      |r $ {} (:type :expr) (:id |SyeSWfe_FRYb) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |BJ-H-Mg_FAtW) (:text |:tree) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |HyMrbMl_YRtW) (:text |markup) (:by |root) (:at 1504774121421)
-                                      |v $ {} (:type :expr) (:id |HJmrZMgOFCFb) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |HJVr-feut0t-) (:text |rest) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |HySBZMl_F0KZ) (:text |coord) (:by |root) (:at 1504774121421)
-                                  |v $ {} (:type :leaf) (:id |H18B-MgOFAY-) (:text |nil) (:by |root) (:at 1504774121421)
-                              |v $ {} (:type :expr) (:id |HkDS-zxdY0K-) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |rJOHbzx_FCKZ) (:text |let) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :expr) (:id |SJtrZGx_tRYb) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :expr) (:id |Sk5BbMgdFRYZ) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |S1oHZGlOYAtW) (:text |child-pair) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :expr) (:id |B1hH-GldFAFW) (:by nil) (:at 1504774121421)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:id |HypBbfldKAK-) (:text |filter-first) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :expr) (:id |rJ0SbMlOYAYZ) (:by nil) (:at 1504774121421)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:id |Hk1UWGeOYCtW) (:text |fn) (:by |root) (:at 1504774121421)
-                                                  |j $ {} (:type :expr) (:id |Sye8bfluKAtW) (:by nil) (:at 1504774121421)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:id |BkZIWfxdtAY-) (:text |child-entry) (:by |root) (:at 1504774121421)
-                                                  |r $ {} (:type :expr) (:id |S1fUZzxuYRKb) (:by nil) (:at 1504774121421)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:id |rJm8bGe_FRKW) (:text |=) (:by |root) (:at 1504774121421)
-                                                      |j $ {} (:type :expr) (:id |ryEUWGgOKCtb) (:by nil) (:at 1504774121421)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:id |rJBUZfx_tRYZ) (:text |get) (:by |root) (:at 1504774121421)
-                                                          |j $ {} (:type :leaf) (:id |ryI8bfxOKAF-) (:text |child-entry) (:by |root) (:at 1504774121421)
-                                                          |r $ {} (:type :leaf) (:id |B1D8bMldK0F-) (:text |0) (:by |root) (:at 1504774121421)
-                                                      |r $ {} (:type :leaf) (:id |Bk_U-MxdFAK-) (:text |coord-head) (:by |root) (:at 1504774121421)
-                                              |r $ {} (:type :expr) (:id |H1t8bMluY0FZ) (:by nil) (:at 1504774121421)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:id |By5UWMldY0t-) (:text |:children) (:by |root) (:at 1504774121421)
-                                                  |j $ {} (:type :leaf) (:id |SJiLZGl_KRYZ) (:text |markup) (:by |root) (:at 1504774121421)
-                                  |r $ {} (:type :expr) (:id |rJ3UZGeOY0tW) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:id |HyTUWGx_tRFb) (:text |if) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :expr) (:id |HkAU-zxdtAYb) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |SJkDbfl_tCKZ) (:text |some?) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |SkgD-zg_tCYZ) (:text |child-pair) (:by |root) (:at 1504774121421)
-                                      |r $ {} (:type :expr) (:id |r1ZDZfx_KRF-) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:id |r1MvZGl_Y0Y-) (:text |recur) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:id |SyXDWMxdFAKZ) (:text |acc) (:by |root) (:at 1504774121421)
-                                          |r $ {} (:type :expr) (:id |rk4PWzl_tAtb) (:by nil) (:at 1504774121421)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:id |ByHDbMgdYCFb) (:text |last) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :leaf) (:id |BJUDWzlutAFZ) (:text |child-pair) (:by |root) (:at 1504774121421)
-                                          |v $ {} (:type :expr) (:id |r1wv-GeOtCYW) (:by nil) (:at 1504774121421)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:id |S1OwWfx_FAF-) (:text |rest) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :leaf) (:id |B1tw-GxutAtW) (:text |coord) (:by |root) (:at 1504774121421)
-                                      |v $ {} (:type :leaf) (:id |BJ9DZMgOtRFW) (:text |nil) (:by |root) (:at 1504774121421)
           |get-markup-at $ {} (:type :expr) (:id |SJpjWfldY0tb) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:id |H10o-MlOYAYW) (:text |defn) (:by |root) (:at 1504774121421)
@@ -9439,9 +9347,6 @@
                   |v $ {} (:type :expr) (:id |BJhU3GgdKRYZ) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |HyT82MxOYRY-) (:text |[]) (:by |root) (:at 1504774121421)
-                  |x $ {} (:type :expr) (:id |S1RUhflOKRKW) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |rkyv3Gx_FAF-) (:text |[]) (:by |root) (:at 1504774121421)
                   |y $ {} (:type :leaf) (:id |B1gDnfxdY0tW) (:text |old-element) (:by |root) (:at 1504774121421)
           |render-children $ {} (:type :expr) (:id |ry-v3feut0K-) (:by nil) (:at 1504774121421)
             :data $ {}
@@ -9452,7 +9357,6 @@
                   |T $ {} (:type :leaf) (:id |rkBDhMxdKCKZ) (:text |children) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |r1Uw3GeOYCtZ) (:text |coord) (:by |root) (:at 1504774121421)
                   |r $ {} (:type :leaf) (:id |H1Dwhfe_tRtZ) (:text |comp-coord) (:by |root) (:at 1504774121421)
-                  |v $ {} (:type :leaf) (:id |HyOD2MldF0K-) (:text |cursor) (:by |root) (:at 1504774121421)
                   |x $ {} (:type :leaf) (:id |BJYvnzgdYAK-) (:text |old-children) (:by |root) (:at 1504774121421)
               |v $ {} (:type :expr) (:id |By5v3MxdFRYW) (:by nil) (:at 1504774121421)
                 :data $ {}
@@ -9550,7 +9454,6 @@
                                                       |j $ {} (:type :leaf) (:id |HkWnhzx_YRK-) (:text |coord) (:by |root) (:at 1504774121421)
                                                       |r $ {} (:type :leaf) (:id |rkfn2GxdKCKW) (:text |k) (:by |root) (:at 1504774121421)
                                                   |v $ {} (:type :leaf) (:id |rJm23zeOtAK-) (:text |comp-coord) (:by |root) (:at 1504774121421)
-                                                  |x $ {} (:type :leaf) (:id |HkEh2fguFAK-) (:text |cursor) (:by |root) (:at 1504774121421)
                                                   |y $ {} (:type :leaf) (:id |S1S22feOKAtZ) (:text |old-child) (:by |root) (:at 1504774121421)
                                               |v $ {} (:type :leaf) (:id |By8nnMgutCY-) (:text |nil) (:by |root) (:at 1504774121421)
           |render-component $ {} (:type :expr) (:id |SyNaiGxdKRFb) (:by nil) (:at 1504774121421)
@@ -9561,7 +9464,6 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:id |BkOTjzx_FAFW) (:text |markup) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |B1t6oMguFCYZ) (:text |coord) (:by |root) (:at 1504774121421)
-                  |r $ {} (:type :leaf) (:id |B1casMx_YCtZ) (:text |cursor) (:by |root) (:at 1504774121421)
                   |v $ {} (:type :leaf) (:id |BksToGgutCK-) (:text |old-element) (:by |root) (:at 1504774121421)
               |v $ {} (:type :expr) (:id |Sy2aiMeuFRK-) (:by nil) (:at 1504774121421)
                 :data $ {}
@@ -9584,37 +9486,6 @@
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |root) (:at 1517742988182) (:text |:name) (:id |rkzGqiv48M)
                               |j $ {} (:type :leaf) (:by |root) (:at 1517742991074) (:text |old-element) (:id |H1XE5oDEUz)
-                      |o $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571939912329) (:id |WE51kOMld)
-                        :data $ {}
-                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571939912864) (:text |or) (:id |AJuLQhfdi)
-                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571939913668) (:id |mqsrRh70V)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571939915176) (:text |and) (:id |FRQWM7KufI)
-                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571939915407) (:id |oMSdQXGPaz)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571939918086) (:text |empty?) (:id |Twuu1E7OQF)
-                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571939923727) (:id |Js4V7AcUqX)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571939923727) (:text |:cursor) (:id |GbForAw5Lw)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571939923727) (:text |markup) (:id |at5BlIkOmq)
-                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571939928332) (:id |PKVad_ncT3)
-                                :data $ {}
-                                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571939931121) (:text |empty?) (:id |rsOe9WpGV)
-                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571939927583) (:id |_lXKZXGzNN)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571939927583) (:text |:cursor) (:id |JFy3uJsAsS)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571939927583) (:text |old-element) (:id |41Xld6x4pA)
-                          |T $ {} (:type :expr) (:by |root) (:at 1517742979770) (:id |_i7cy1tOHz)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |root) (:at 1517742981457) (:text |=) (:id |Bk3YiP4IMleaf)
-                              |j $ {} (:type :expr) (:by |root) (:at 1517742983263) (:id |BJxycsPV8z)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1554636347567) (:text |:cursor) (:id |r1CKowELM)
-                                  |j $ {} (:type :leaf) (:by |root) (:at 1517742985709) (:text |markup) (:id |B1xb5jvELM)
-                              |r $ {} (:type :expr) (:by |root) (:at 1517742986542) (:id |SJXqiPNLf)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1554636350210) (:text |:cursor) (:id |rkzGqiv48M)
-                                  |j $ {} (:type :leaf) (:by |root) (:at 1517742991074) (:text |old-element) (:id |H1XE5oDEUz)
                       |r $ {} (:type :expr) (:by |root) (:at 1517742434052) (:id |Sk9PtD4If)
                         :data $ {}
                           |T $ {} (:type :leaf) (:id |Bk40jfxdKRF-) (:text |=seq) (:by |root) (:at 1504774121421)
@@ -9666,17 +9537,6 @@
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:id |ryG-2zguYCtW) (:text |:name) (:by |root) (:at 1504774121421)
                                       |j $ {} (:type :leaf) (:id |BJmb3fldK0F-) (:text |markup) (:by |root) (:at 1504774121421)
-                          |x $ {} (:type :expr) (:id |ryN-nGxuFRKW) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |H1r-nMx_YAFW) (:text |new-cursor) (:by |root) (:at 1504774121421)
-                              |b $ {} (:type :expr) (:id |SJbb671p9-) (:by |root) (:at 1505715129176)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |or) (:id |Bkx-aXk65Z) (:by |root) (:at 1505715129965)
-                                  |j $ {} (:type :expr) (:id |ry76Qyp5b) (:by |root) (:at 1505715130563)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:text |:cursor) (:id |rJWzpXya5Z) (:by |root) (:at 1505715131720)
-                                      |j $ {} (:type :leaf) (:text |markup) (:id |SkMV67k65-) (:by |root) (:at 1505715133304)
-                                  |r $ {} (:type :leaf) (:text |cursor) (:id |SJPpmk65Z) (:by |root) (:at 1505715136281)
                           |y $ {} (:type :expr) (:id |Syuf3GeuYRKZ) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |S1FMnfldtCYb) (:text |render) (:by |root) (:at 1504774121421)
@@ -9686,19 +9546,12 @@
                                   |j $ {} (:type :leaf) (:id |ry2z3zxOt0Y-) (:text |markup) (:by |root) (:at 1504774121421)
                           |yT $ {} (:type :expr) (:id |rJafhMlOYCKW) (:by nil) (:at 1504774121421)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:id |B10GhGldFCtW) (:text |half-render) (:by |root) (:at 1504774121421)
+                              |T $ {} (:type :leaf) (:id |B10GhGldFCtW) (:text |markup-tree) (:by |rJoDgvdeG) (:at 1584719850204)
                               |j $ {} (:type :expr) (:id |ryy7hzluFRFW) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:id |rklQnzluF0FZ) (:text |apply) (:by |root) (:at 1504774121421)
                                   |j $ {} (:type :leaf) (:id |H1-X3MeuKRFZ) (:text |render) (:by |root) (:at 1504774121421)
                                   |r $ {} (:type :leaf) (:id |H1G72Ml_t0t-) (:text |args) (:by |root) (:at 1504774121421)
-                          |yj $ {} (:type :expr) (:id |rJ77hMluKAtW) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |B1Nm2fl_tRY-) (:text |markup-tree) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:by |root) (:at 1536678990655) (:id |HpfBoHnqsG)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |root) (:at 1536678990655) (:text |half-render) (:id |N1mXAhjrWH)
-                                  |j $ {} (:type :leaf) (:by |root) (:at 1536678990655) (:text |new-cursor) (:id |13jxXtamBl)
                           |yr $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572084771304) (:id |PWpv1t0djW)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572084771961) (:text |local) (:id |PWpv1t0djWleaf)
@@ -9796,15 +9649,10 @@
                                               |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |markup-tree) (:id |Voj2JzWV5C)
                                               |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |new-coord) (:id |wIToF1TDyK)
                                               |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |new-coord) (:id |ahuaMUZuze)
-                                              |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |new-cursor) (:id |hQBJN6OgWe)
                                               |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571575501498) (:id |VhpLYN5TrJ)
                                                 :data $ {}
                                                   |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |:tree) (:id |7HoypfTsd0)
                                                   |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |old-element) (:id |IuUbb_rRXU)
-                                      |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571573162131) (:id |zTHF1O1E3t)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571573163946) (:text |:cursor) (:id |zTHF1O1E3tleaf)
-                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571573178978) (:text |new-cursor) (:id |jfesnwVofL)
                                       |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572084767138) (:id |ZYB1z5mBrK)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572084767994) (:text |:local) (:id |ZYB1z5mBrKleaf)
@@ -9878,15 +9726,10 @@
                                                   |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575595432) (:text |node-tree) (:id |D0k2yY3_JT)
                                                   |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |new-coord) (:id |59wMVC9z1R)
                                                   |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |new-coord) (:id |sRJ55uYGeB)
-                                                  |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |new-cursor) (:id |G5OTfflP6J)
                                                   |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571575509792) (:id |ewb-2t1sX4)
                                                     :data $ {}
                                                       |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |:tree) (:id |IURMPpvDPJ)
                                                       |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |old-element) (:id |UOVqOIRDFS)
-                                          |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571573922883) (:id |N2TdZdyA8p)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571573924054) (:text |:cursor) (:id |N2TdZdyA8pleaf)
-                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571573926600) (:text |new-cursor) (:id |tue8xPiUgV)
                                           |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571573927614) (:id |tL7WypUlU)
                                             :data $ {}
                                               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571573929740) (:text |:effects) (:id |tL7WypUlUleaf)
@@ -9916,7 +9759,6 @@
                   |T $ {} (:type :leaf) (:id |rJjhhMgutRFW) (:text |markup) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |BJn23Me_K0F-) (:text |coord) (:by |root) (:at 1504774121421)
                   |r $ {} (:type :leaf) (:id |SkT33GgOYAKZ) (:text |comp-coord) (:by |root) (:at 1504774121421)
-                  |v $ {} (:type :leaf) (:id |HyA23MeOY0KZ) (:text |cursor) (:by |root) (:at 1504774121421)
                   |x $ {} (:type :leaf) (:id |r1ya2GguFRFW) (:text |old-element) (:by |root) (:at 1504774121421)
               |v $ {} (:type :expr) (:id |Skxp3GguYAK-) (:by nil) (:at 1504774121421)
                 :data $ {}
@@ -9939,7 +9781,6 @@
                               |j $ {} (:type :leaf) (:id |rJ3p2zgdFAFW) (:text |children) (:by |root) (:at 1504774121421)
                               |r $ {} (:type :leaf) (:id |SJa6nGedF0FZ) (:text |coord) (:by |root) (:at 1504774121421)
                               |v $ {} (:type :leaf) (:id |rJRa2Gx_FRKb) (:text |comp-coord) (:by |root) (:at 1504774121421)
-                              |x $ {} (:type :leaf) (:id |B1yAnze_YRtZ) (:text |cursor) (:by |root) (:at 1504774121421)
                               |y $ {} (:type :expr) (:id |B1l0hGxOKCFZ) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:id |By-AnGxutRFb) (:text |:children) (:by |root) (:at 1504774121421)
@@ -9969,7 +9810,6 @@
                   |T $ {} (:type :leaf) (:id |rk2kaGe_F0FW) (:text |markup) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |H161azg_FRtb) (:text |coord) (:by |root) (:at 1504774121421)
                   |r $ {} (:type :leaf) (:id |BkAypzxdFCFb) (:text |comp-coord) (:by |root) (:at 1505325712568)
-                  |v $ {} (:type :leaf) (:id |ByJg6zeOKAFZ) (:text |cursor) (:by |root) (:at 1504774121421)
                   |x $ {} (:type :leaf) (:id |BJleafl_F0F-) (:text |old-element) (:by |root) (:at 1504774121421)
               |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571933402610) (:id |75yC3HR8o)
                 :data $ {}
@@ -9992,7 +9832,6 @@
                           |T $ {} (:type :leaf) (:id |H1DxpflOF0F-) (:text |render-component) (:by |root) (:at 1504774121421)
                           |j $ {} (:type :leaf) (:id |By_gpGguK0KW) (:text |markup) (:by |root) (:at 1504774121421)
                           |r $ {} (:type :leaf) (:id |SytepMl_K0t-) (:text |coord) (:by |root) (:at 1504774121421)
-                          |v $ {} (:type :leaf) (:id |BkcepMg_FCY-) (:text |cursor) (:by |root) (:at 1504774121421)
                           |x $ {} (:type :leaf) (:id |HJilpzlutAK-) (:text |old-element) (:by |root) (:at 1504774121421)
                   |b $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1572086214457) (:id |51VzhyLK9D)
                     :data $ {}
@@ -10019,7 +9858,6 @@
                           |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086214457) (:text |render-component) (:id |oinAY2ZN9h)
                           |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086214457) (:text |markup) (:id |pVyY92jhoj)
                           |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086214457) (:text |coord) (:id |G23xo0EJM1)
-                          |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086214457) (:text |cursor) (:id |VVUrZpBdv7S)
                           |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086227632) (:text |nil) (:id |hEDfIbJOZ)
                   |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571933408387) (:id |EjLM8N8MaB)
                     :data $ {}
@@ -10040,7 +9878,6 @@
                           |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |markup) (:id |tgyZRY0Pqo)
                           |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |coord) (:id |O4_YApW2zU)
                           |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |comp-coord) (:id |bKwJotpF6b)
-                          |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |cursor) (:id |o-0xzqYIJp)
                           |y $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |old-element) (:id |V8tGCOcb69)
                   |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571933408387) (:id |lbgcsEmHN3)
                     :data $ {}
@@ -10068,7 +9905,6 @@
                           |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |markup) (:id |tgyZRY0Pqo)
                           |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |coord) (:id |O4_YApW2zU)
                           |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |comp-coord) (:id |bKwJotpF6b)
-                          |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |cursor) (:id |o-0xzqYIJp)
                           |y $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086253273) (:text |nil) (:id |V8tGCOcb69)
                   |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571933416946) (:id |fp9rJPCXv)
                     :data $ {}
@@ -10209,6 +10045,62 @@
                     |T $ {} (:type :leaf) (:by |root) (:at 1540829972147) (:text |[]) (:id |SiVGzUClZY)
                     |j $ {} (:type :leaf) (:by |root) (:at 1540829974627) (:text |respo.core) (:id |dUTSsklgYt)
         :defs $ {}
+          |>> $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717583807)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717583807) (:text |defn) (:id |5Gn5BO7oQF)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717583807) (:text |>>) (:id |q35xDmJrqG)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717583807)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717587429) (:text |states) (:id |pqdFuYHGBF)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717589003) (:text |k) (:id |wGLZ_Nsnl)
+                :id |NN669968ZV
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717590808)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717593513) (:text |let) (:id |6bFO-vTDfleaf)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717593734)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717593912)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717602856) (:text |parent-cursor) (:id |RRy7B-KnHN)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717633898)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717603162)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717604395) (:text |:cursor) (:id |cvKZnNP1j6)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717605146) (:text |states) (:id |EDGpexhuSo)
+                                :id |TISRpqQCI
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717634441) (:text |or) (:id |H-1mFnY9Z)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717635438)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717635678) (:text |[]) (:id |2fntgBIfbk)
+                                :id |-KLfrFl-h
+                            :id |KIxtrCUDeK
+                        :id |w_bd9-3hhm
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717607005)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717615395) (:text |branch) (:id |vmMtIVJWlleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717616411)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717618041) (:text |get) (:id |D23yhog40)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717618973) (:text |states) (:id |0rPkI0-UP)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717619385) (:text |k) (:id |CbjSVDewI)
+                            :id |8Mmm3Xm8k7
+                        :id |vmMtIVJWl
+                    :id |gr3ncHiLx1
+                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717620560)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717622795) (:text |assoc) (:id |w7BYCszeMJleaf)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717623675) (:text |branch) (:id |SWsa5csx-5)
+                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717625744) (:text |:cursor) (:id |bQGuIruRe)
+                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584717626141)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717626655) (:text |conj) (:id |obHP2JXJfC)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717630765) (:text |parent-cursor) (:id |j1gjnNunFv)
+                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584717631832) (:text |k) (:id |1hEWQUQLA)
+                        :id |zHiynpPSh
+                    :id |w7BYCszeMJ
+                :id |6bFO-vTDf
+            :id |NuE6ZQqWHZ
           |*changes-logger $ {} (:type :expr) (:id |HJwp4lzxuY0KZ) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:id |B1OpNgGe_t0Fb) (:text |defonce) (:by |root) (:at 1504774121421)

--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,12 @@
 
-{:paths ["src" "macros"]}
+{
+  :paths ["src" "macros"]
+  :aliases {
+    :release {
+      :extra-deps {
+        appliedscience/deps-library {:mvn/version "0.3.4"}
+      }
+      :main-opts ["-m" "deps-library.release"]
+    }
+  }
+}

--- a/macros/respo/core.clj
+++ b/macros/respo/core.clj
@@ -9,8 +9,7 @@
     (merge respo.schema/component
       {:args (list ~@params) ,
        :name ~(keyword comp-name),
-       :render (fn [~@params]
-                 (defn ~(symbol (str "call-" comp-name)) [~'%cursor] ~@body))})))
+       :render (fn [~@params] ~@body)})))
 
 (def support-elements '[a body br button canvas code div footer
                         h1 h2 head header html hr i img input li link video audio
@@ -40,23 +39,12 @@
   ([content style] `(span {:inner-text ~content, :style ~style}))
   ([el content style] `(~el {:inner-text ~content, :style ~style})))
 
-(defmacro cursor-> [k component states & args]
-  `(assoc (~component (get ~states ~k) ~@args) :cursor (conj ~'%cursor ~k)))
-
 (defmacro list->
   ([props children]
     `(respo.core/create-list-element :div ~props ~children))
   ([tag props children]
     (assert (keyword? tag) "tag in list-> should be keyword")
     `(respo.core/create-list-element ~tag ~props ~children)))
-
-(defmacro action-> [op op-data]
-  `(fn [~'%e d!# m!#]
-    (d!# ~op ~op-data)))
-
-(defmacro mutation-> [state]
-  `(fn [~'%e d!# m!#]
-    (m!# ~state)))
 
 (defmacro defeffect [effect-name args params & body]
   (assert (and (sequential? args) (every? symbol? args)) "args should be simple sequence")

--- a/meyvn.edn
+++ b/meyvn.edn
@@ -1,9 +1,0 @@
-
-{:pom {:group-id "respo",
-       :artifact-id "respo",
-       :version "0.11.5",
-       :name "Respo: A virtual DOM library in ClojureScript."}
- :packaging {:jar {:enabled true
-                   :remote-repository {:id "clojars"
-                                       :url "https://clojars.org/repo"}}}
- :scm {:enabled true}}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Virtual DOM library",
   "main": "index.js",
   "scripts": {
+    "deploy": "clj -A:release",
+    "m2": "clj -A:release install",
     "upload": "rsync -r dist/ repo.respo-mvc.org:repo/Respo/respo",
     "html": "cp assets/* target/",
     "html-dist": "cp assets/* dist/",
@@ -28,9 +30,9 @@
   "homepage": "https://github.com/Respo/respo#readme",
   "dependencies": {},
   "devDependencies": {
-    "http-server": "^0.11.1",
-    "shadow-cljs": "^2.8.69",
+    "http-server": "^0.12.1",
+    "shadow-cljs": "^2.8.93",
     "source-map-support": "^0.5.16",
-    "ws": "^7.2.0"
+    "ws": "^7.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "m2": "clj -A:release install",
     "upload": "rsync -r dist/ repo.respo-mvc.org:repo/Respo/respo",
     "html": "cp assets/* target/",
-    "html-dist": "cp assets/* dist/",
+    "html-dist": "mkdir -p dist/ && cp assets/* dist/",
     "watch": "shadow-cljs watch app",
     "watch-test": "shadow-cljs watch test",
     "compile-test": "shadow-cljs compile test",

--- a/release.edn
+++ b/release.edn
@@ -1,0 +1,6 @@
+{:version "0.12.0-a1"
+ :group-id "respo"
+ :artifact-id "respo"
+ :skip-tag true
+ :description "Respo: A virtual DOM library in ClojureScript."
+ :scm-url "https://github.com/Respo/respo"}

--- a/scripts/comp.clj
+++ b/scripts/comp.clj
@@ -4,8 +4,7 @@
     `(merge respo.schema/component
       {:args (list ~@~params) ,
        :name ~(keyword comp-name),
-       :render (fn [~@~params]
-                 (defn ~~(symbol (str "call-" comp-name)) [~~'%cursor] ~@~body))})))
+       :render (fn [~@~params] ~@~body)})))
 
 (defcomp comp-a [a] (div {}))
 

--- a/src/respo/app/comp/container.cljs
+++ b/src/respo/app/comp/container.cljs
@@ -1,6 +1,6 @@
 
 (ns respo.app.comp.container
-  (:require [respo.core :refer [defcomp div span <> cursor->]]
+  (:require [respo.core :refer [defcomp div span <> >>]]
             [respo.app.comp.todolist :refer [comp-todolist]]))
 
 (def style-global {:font-family "Avenir,Verdana"})
@@ -10,8 +10,8 @@
 (defcomp
  comp-container
  (store)
- (let [state (:states store)]
+ (let [states (:states store)]
    (div
     {:style style-global}
-    (cursor-> :todolist comp-todolist state (:tasks store))
+    (comp-todolist (>> states :todolist) (:tasks store))
     (div {:style style-states} (<> (str "states: " (pr-str (:states store))))))))

--- a/src/respo/app/core.cljs
+++ b/src/respo/app/core.cljs
@@ -10,8 +10,10 @@
 (defonce *store (atom schema/store))
 
 (defn dispatch! [op op-data]
-  (comment println op)
-  (let [op-id (get-id!), store (updater @*store op op-data op-id)] (reset! *store store)))
+  (comment println op op-data)
+  (if (vector? op)
+    (recur :states [op op-data])
+    (let [op-id (get-id!), store (updater @*store op op-data op-id)] (reset! *store store))))
 
 (defn handle-ssr! [mount-target]
   (realize-ssr! mount-target (comp-container @*store) dispatch!))

--- a/src/respo/app/schema.cljs
+++ b/src/respo/app/schema.cljs
@@ -1,6 +1,6 @@
 
 (ns respo.app.schema )
 
-(def store {:tasks [], :states {}})
+(def store {:tasks [], :states {}, :cursor []})
 
 (def task {:id nil, :text "", :done? false})

--- a/src/respo/app/updater.cljs
+++ b/src/respo/app/updater.cljs
@@ -1,10 +1,12 @@
 
-(ns respo.app.updater (:require [clojure.string :as string] [respo.cursor :refer [mutate]]))
+(ns respo.app.updater (:require [clojure.string :as string]))
 
 (defn updater [store op-type op-data op-id]
   (comment println (pr-str store) (pr-str op-type) (pr-str op-data))
   (case op-type
-    :states (update store :states (mutate op-data))
+    :states
+      (let [[cursor new-state] op-data]
+        (assoc-in store (concat [:states] cursor [:data]) new-state))
     :add
       (update store :tasks (fn [tasks] (conj tasks {:text op-data, :id op-id, :done? false})))
     :remove

--- a/src/respo/controller/resolve.cljs
+++ b/src/respo/controller/resolve.cljs
@@ -29,31 +29,12 @@
           (recur element (subvec coord 0 (- (count coord) 1)) event-name)
           nil)))))
 
-(defn get-component-at
-  ([markup coord] (get-component-at nil markup coord))
-  ([acc markup coord]
-   (if (empty? coord)
-     acc
-     (let [coord-head (first coord)]
-       (if (component? markup)
-         (if (= (:name markup) coord-head) (recur markup (:tree markup) (rest coord)) nil)
-         (let [child-pair (filter-first
-                           (fn [child-entry] (= (get child-entry 0) coord-head))
-                           (:children markup))]
-           (if (some? child-pair) (recur acc (last child-pair) (rest coord)) nil)))))))
-
 (defn build-deliver-event [*global-element dispatch!]
   (fn [coord event-name simple-event]
     (let [target-element (find-event-target @*global-element coord event-name)
-          target-component (get-component-at @*global-element coord)
-          this-cursor (:cursor target-component)
-          target-listener (get (:event target-element) event-name)
-          mutate! (fn
-                    ([next-state] (dispatch! :states [this-cursor next-state]))
-                    ([cursor next-state] (dispatch! :states [cursor next-state])))]
-      (if (nil? target-component) (println "Found no component for:" coord))
+          target-listener (get (:event target-element) event-name)]
       (if (some? target-listener)
         (do
          (comment println "listener found:" coord event-name)
-         (target-listener simple-event dispatch! mutate!))
+         (target-listener simple-event dispatch!))
         (comment println "found no listener:" coord event-name)))))

--- a/src/respo/core.cljs
+++ b/src/respo/core.cljs
@@ -19,6 +19,10 @@
 
 (defonce *global-element (atom nil))
 
+(defn >> [states k]
+  (let [parent-cursor (or (:cursor states) []), branch (get states k)]
+    (assoc branch :cursor (conj parent-cursor k))))
+
 (defn clear-cache! [] (reset! *dom-element nil))
 
 (defn confirm-child [x]

--- a/src/respo/cursor.cljs
+++ b/src/respo/cursor.cljs
@@ -1,6 +1,0 @@
-
-(ns respo.cursor )
-
-(defn mutate [op-data]
-  (fn [states]
-    (let [[cursor next-state] op-data] (assoc-in states (conj cursor :data) next-state))))

--- a/src/respo/schema.cljs
+++ b/src/respo/schema.cljs
@@ -9,7 +9,6 @@
    :render nil,
    :effects [],
    :tree nil,
-   :cursor nil,
    :local nil})
 
 (def effect

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,8 +4,8 @@
 
 asn1.js@^4.0.0:
   version "4.10.1"
-  resolved "https://registry.npm.taobao.org/asn1.js/download/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
-  integrity sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
+  integrity sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -13,43 +13,48 @@ asn1.js@^4.0.0:
 
 assert@^1.1.1:
   version "1.5.0"
-  resolved "https://registry.npm.taobao.org/assert/download/assert-1.5.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fassert%2Fdownload%2Fassert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
-  integrity sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
+  integrity sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==
   dependencies:
     object-assign "^4.1.1"
     util "0.10.3"
 
-async-limiter@^1.0.0, async-limiter@~1.0.0:
+async-limiter@~1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/async-limiter/download/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 async@^2.6.2:
   version "2.6.3"
-  resolved "https://registry.npm.taobao.org/async/download/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
     lodash "^4.17.14"
 
 base64-js@^1.0.2:
   version "1.3.1"
-  resolved "https://registry.npm.taobao.org/base64-js/download/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
+basic-auth@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.1.0.tgz#45221ee429f7ee1e5035be3f51533f1cdfd29884"
+  integrity sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
-  resolved "https://registry.npm.taobao.org/bn.js/download/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
-  integrity sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
 brorand@^1.0.1:
   version "1.1.0"
-  resolved "https://registry.npm.taobao.org/brorand/download/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-aes/download/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
-  integrity sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
   dependencies:
     buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
@@ -60,8 +65,8 @@ browserify-aes@^1.0.0, browserify-aes@^1.0.4:
 
 browserify-cipher@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/browserify-cipher/download/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
-  integrity sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=
+  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
+  integrity sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
   dependencies:
     browserify-aes "^1.0.4"
     browserify-des "^1.0.0"
@@ -69,8 +74,8 @@ browserify-cipher@^1.0.0:
 
 browserify-des@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/browserify-des/download/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
-  integrity sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=
+  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
+  integrity sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
   dependencies:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
@@ -79,7 +84,7 @@ browserify-des@^1.0.0:
 
 browserify-rsa@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.npm.taobao.org/browserify-rsa/download/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
   integrity sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
   dependencies:
     bn.js "^4.1.0"
@@ -87,7 +92,7 @@ browserify-rsa@^4.0.0:
 
 browserify-sign@^4.0.0:
   version "4.0.4"
-  resolved "https://registry.npm.taobao.org/browserify-sign/download/browserify-sign-4.0.4.tgz#aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298"
+  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.0.4.tgz#aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298"
   integrity sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=
   dependencies:
     bn.js "^4.1.1"
@@ -100,25 +105,25 @@ browserify-sign@^4.0.0:
 
 browserify-zlib@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-zlib/download/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
-  integrity sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
+  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   dependencies:
     pako "~1.0.5"
 
 buffer-from@^1.0.0:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer-xor@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.npm.taobao.org/buffer-xor/download/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^4.3.0:
-  version "4.9.1"
-  resolved "https://registry.npm.taobao.org/buffer/download/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -126,54 +131,54 @@ buffer@^4.3.0:
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npm.taobao.org/builtin-status-codes/download/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
-  resolved "https://registry.npm.taobao.org/cipher-base/download/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
-  integrity sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-colors@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npm.taobao.org/colors/download/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+colors@^1.3.3:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 console-browserify@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/console-browserify/download/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
-  integrity sha1-ZwY871fOts9Jk6KrOlWECujEkzY=
+  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
+  integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
 constants-browserify@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/constants-browserify/download/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+  resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
 core-util-is@~1.0.0:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/core-util-is/download/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-corser@~2.0.0:
+corser@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.npm.taobao.org/corser/download/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
+  resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
   integrity sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
 
 create-ecdh@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.npm.taobao.org/create-ecdh/download/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
-  integrity sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
+  integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/create-hash/download/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
-  integrity sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
@@ -183,8 +188,8 @@ create-hash@^1.1.0, create-hash@^1.1.2:
 
 create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
   version "1.1.7"
-  resolved "https://registry.npm.taobao.org/create-hmac/download/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
-  integrity sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
   dependencies:
     cipher-base "^1.0.3"
     create-hash "^1.1.0"
@@ -195,8 +200,8 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
-  resolved "https://registry.npm.taobao.org/crypto-browserify/download/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
-  integrity sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
   dependencies:
     browserify-cipher "^1.0.0"
     browserify-sign "^4.0.0"
@@ -212,23 +217,23 @@ crypto-browserify@^3.11.0:
 
 debug@^3.0.0, debug@^3.1.1:
   version "3.2.6"
-  resolved "https://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha1-6D0X3hbYp++3cX7b5fsQE17uYps=
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
 des.js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npm.taobao.org/des.js/download/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
-  integrity sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
+  integrity sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
-  resolved "https://registry.npm.taobao.org/diffie-hellman/download/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
-  integrity sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=
+  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
+  integrity sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
   dependencies:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
@@ -236,13 +241,13 @@ diffie-hellman@^5.0.0:
 
 domain-browser@^1.1.1:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/domain-browser/download/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
-  integrity sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=
+  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+  integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
-ecstatic@^3.0.0:
+ecstatic@^3.3.2:
   version "3.3.2"
-  resolved "https://registry.npm.taobao.org/ecstatic/download/ecstatic-3.3.2.tgz#6d1dd49814d00594682c652adb66076a69d46c48"
-  integrity sha1-bR3UmBTQBZRoLGUq22YHamnUbEg=
+  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.3.2.tgz#6d1dd49814d00594682c652adb66076a69d46c48"
+  integrity sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==
   dependencies:
     he "^1.1.1"
     mime "^1.6.0"
@@ -250,9 +255,9 @@ ecstatic@^3.0.0:
     url-join "^2.0.5"
 
 elliptic@^6.0.0:
-  version "6.5.1"
-  resolved "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.1.tgz#c380f5f909bf1b9b4428d028cd18d3b0efd6b52b"
-  integrity sha1-w4D1+Qm/G5tEKNAozRjTsO/WtSs=
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -264,32 +269,32 @@ elliptic@^6.0.0:
 
 eventemitter3@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.npm.taobao.org/eventemitter3/download/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
-  integrity sha1-1lF2FjiH7lnzhtZMgmELaWpKdOs=
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
+  integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
 
 events@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npm.taobao.org/events/download/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
-  integrity sha1-mgoN+vYok9krh1uPJpjKQRSXPog=
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
+  integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.npm.taobao.org/evp_bytestokey/download/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
-  integrity sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=
+  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
+  integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
 follow-redirects@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
-  integrity sha1-jVvNxltxCP4VCGScecEtcy3O208=
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.10.0.tgz#01f5263aee921c6a54fb91667f08f4155ce169eb"
+  integrity sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==
   dependencies:
     debug "^3.0.0"
 
 hash-base@^3.0.0:
   version "3.0.4"
-  resolved "https://registry.npm.taobao.org/hash-base/download/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
   integrity sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=
   dependencies:
     inherits "^2.0.1"
@@ -297,93 +302,95 @@ hash-base@^3.0.0:
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
-  resolved "https://registry.npm.taobao.org/hash.js/download/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
 he@^1.1.1:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/he/download/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
-  integrity sha1-hK5l+n6vsWX922FWauFLrwVmTw8=
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/hmac-drbg/download/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
   dependencies:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-http-proxy@^1.8.1:
+http-proxy@^1.17.0:
   version "1.18.0"
-  resolved "https://registry.npm.taobao.org/http-proxy/download/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
-  integrity sha1-2+VfY+daNH2389mZdPJpKjFKajo=
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
+  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
   dependencies:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
-http-server@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.npm.taobao.org/http-server/download/http-server-0.11.1.tgz#2302a56a6ffef7f9abea0147d838a5e9b6b6a79b"
-  integrity sha1-IwKlam/+9/mr6gFH2Dil6ba2p5s=
+http-server@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/http-server/-/http-server-0.12.1.tgz#629ae9a8c786587ee21b0ff087b670f69b809d8c"
+  integrity sha512-T0jB+7J7GJ2Vo+a4/T7P7SbQ3x2GPDnqRqQXdfEuPuUOmES/9NBxPnDm7dh1HGEeUWqUmLUNtGV63ZC5Uy3tGA==
   dependencies:
-    colors "1.0.3"
-    corser "~2.0.0"
-    ecstatic "^3.0.0"
-    http-proxy "^1.8.1"
-    opener "~1.4.0"
-    optimist "0.6.x"
-    portfinder "^1.0.13"
-    union "~0.4.3"
+    basic-auth "^1.0.3"
+    colors "^1.3.3"
+    corser "^2.0.1"
+    ecstatic "^3.3.2"
+    http-proxy "^1.17.0"
+    opener "^1.5.1"
+    optimist "~0.6.1"
+    portfinder "^1.0.20"
+    secure-compare "3.0.1"
+    union "~0.5.0"
 
 https-browserify@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/https-browserify/download/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
 ieee754@^1.1.4:
   version "1.1.13"
-  resolved "https://registry.npm.taobao.org/ieee754/download/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 inherits@2.0.1:
   version "2.0.1"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 inherits@2.0.3:
   version "2.0.3"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 lodash@^4.17.14:
   version "4.17.15"
-  resolved "https://registry.npm.taobao.org/lodash/download/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 md5.js@^1.3.4:
   version "1.3.5"
-  resolved "https://registry.npm.taobao.org/md5.js/download/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
-  integrity sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
@@ -391,58 +398,53 @@ md5.js@^1.3.4:
 
 miller-rabin@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.npm.taobao.org/miller-rabin/download/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
-  integrity sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=
+  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
   dependencies:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
 mime@^1.6.0:
   version "1.6.0"
-  resolved "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
-  integrity sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/minimalistic-assert/download/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.npm.taobao.org/minimist/download/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.npm.taobao.org/minimist/download/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+minimist@^1.1.0, minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@~0.0.1:
   version "0.0.10"
-  resolved "https://registry.npm.taobao.org/minimist/download/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.npm.taobao.org/mkdirp/download/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
+  integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
   dependencies:
-    minimist "0.0.8"
+    minimist "^1.2.5"
 
 ms@^2.1.1:
   version "2.1.2"
-  resolved "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 node-libs-browser@^2.0.0:
   version "2.2.1"
-  resolved "https://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
-  integrity sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
+  integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
   dependencies:
     assert "^1.1.1"
     browserify-zlib "^0.2.0"
@@ -470,17 +472,17 @@ node-libs-browser@^2.0.0:
 
 object-assign@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-opener@~1.4.0:
-  version "1.4.3"
-  resolved "https://registry.npm.taobao.org/opener/download/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
-  integrity sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=
+opener@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
-optimist@0.6.x:
+optimist@~0.6.1:
   version "0.6.1"
-  resolved "https://registry.npm.taobao.org/optimist/download/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
   dependencies:
     minimist "~0.0.1"
@@ -488,18 +490,18 @@ optimist@0.6.x:
 
 os-browserify@^0.3.0:
   version "0.3.0"
-  resolved "https://registry.npm.taobao.org/os-browserify/download/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
+  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
 pako@~1.0.5:
-  version "1.0.10"
-  resolved "https://registry.npm.taobao.org/pako/download/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
-  integrity sha1-Qyi621CGpCaqkPVBl31JVdpclzI=
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parse-asn1@^5.0.0:
   version "5.1.5"
-  resolved "https://registry.npm.taobao.org/parse-asn1/download/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
-  integrity sha1-ADJxND2ljclMrOSU+u89IUfs6g4=
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
+  integrity sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
@@ -510,13 +512,13 @@ parse-asn1@^5.0.0:
 
 path-browserify@0.0.1:
   version "0.0.1"
-  resolved "https://registry.npm.taobao.org/path-browserify/download/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
-  integrity sha1-5sTd1+06onxoogzE5Q4aTug7vEo=
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
+  integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
 
 pbkdf2@^3.0.3:
   version "3.0.17"
-  resolved "https://registry.npm.taobao.org/pbkdf2/download/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
-  integrity sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
+  integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -524,10 +526,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-portfinder@^1.0.13:
+portfinder@^1.0.20:
   version "1.0.25"
-  resolved "https://registry.npm.taobao.org/portfinder/download/portfinder-1.0.25.tgz#254fd337ffba869f4b9d37edc298059cb4d35eca"
-  integrity sha1-JU/TN/+6hp9LnTftwpgFnLTTXso=
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.25.tgz#254fd337ffba869f4b9d37edc298059cb4d35eca"
+  integrity sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==
   dependencies:
     async "^2.6.2"
     debug "^3.1.1"
@@ -535,18 +537,18 @@ portfinder@^1.0.13:
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
-  resolved "https://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha1-eCDZsWEgzFXKmud5JoCufbptf+I=
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 process@^0.11.10:
   version "0.11.10"
-  resolved "https://registry.npm.taobao.org/process/download/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 public-encrypt@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.npm.taobao.org/public-encrypt/download/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
-  integrity sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=
+  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
+  integrity sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
   dependencies:
     bn.js "^4.1.0"
     browserify-rsa "^4.0.0"
@@ -557,48 +559,48 @@ public-encrypt@^4.0.0:
 
 punycode@1.3.2:
   version "1.3.2"
-  resolved "https://registry.npm.taobao.org/punycode/download/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@^1.2.4:
   version "1.4.1"
-  resolved "https://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-qs@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npm.taobao.org/qs/download/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
-  integrity sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=
+qs@^6.4.0:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
+  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
-  resolved "https://registry.npm.taobao.org/querystring-es3/download/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
 
 querystring@0.2.0:
   version "0.2.0"
-  resolved "https://registry.npm.taobao.org/querystring/download/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
-  resolved "https://registry.npm.taobao.org/randombytes/download/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
 
 randomfill@^1.0.3:
   version "1.0.4"
-  resolved "https://registry.npm.taobao.org/randomfill/download/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
-  integrity sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=
+  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
+  integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
 readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
-  integrity sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -610,100 +612,105 @@ readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
 
 readline-sync@^1.4.7:
   version "1.4.10"
-  resolved "https://registry.npm.taobao.org/readline-sync/download/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
-  integrity sha1-Qd9/u0tjEtZzARWUFFcFv1bYhzs=
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
 
 requires-port@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/requires-port/download/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npm.taobao.org/ripemd160/download/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
-  integrity sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.0"
-  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk=
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
-  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha1-mR7GnSluAxN0fVm9/St0XDX4go0=
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+secure-compare@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
+  integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
 
 setimmediate@^1.0.4:
   version "1.0.5"
-  resolved "https://registry.npm.taobao.org/setimmediate/download/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
-  resolved "https://registry.npm.taobao.org/sha.js/download/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shadow-cljs-jar@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npm.taobao.org/shadow-cljs-jar/download/shadow-cljs-jar-1.3.1.tgz#a5f8ab7664b40e11345837e4c6bce8e0ac9b2cc3"
-  integrity sha1-pfirdmS0DhE0WDfkxrzo4KybLMM=
+shadow-cljs-jar@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
+  integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
 
-shadow-cljs@^2.8.69:
-  version "2.8.69"
-  resolved "https://registry.npm.taobao.org/shadow-cljs/download/shadow-cljs-2.8.69.tgz#a646926ce0ba2b0b0f1086925a1048fdd69ebb08"
-  integrity sha1-pkaSbOC6KwsPEIaSWhBI/daeuwg=
+shadow-cljs@^2.8.93:
+  version "2.8.93"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.93.tgz#60d475658819246892f74159ce5a6026b275892e"
+  integrity sha512-JWxdfLZextA55oo/ZkTt+D5aszaNs0UR/V7j/jKI7aSbc46uJrycSalkQEvTzFkr+E7BiLdBsI6zBqezRgEgDw==
   dependencies:
     mkdirp "^0.5.1"
     node-libs-browser "^2.0.0"
     readline-sync "^1.4.7"
-    shadow-cljs-jar "1.3.1"
+    shadow-cljs-jar "1.3.2"
     source-map-support "^0.4.15"
     which "^1.3.1"
     ws "^3.0.0"
 
 source-map-support@^0.4.15:
   version "0.4.18"
-  resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  integrity sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
   dependencies:
     source-map "^0.5.6"
 
 source-map-support@^0.5.16:
   version "0.5.16"
-  resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
-  integrity sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map@^0.5.6:
   version "0.5.7"
-  resolved "https://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 source-map@^0.6.0:
   version "0.6.1"
-  resolved "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha1-dHIq8y6WFOnCh6jQu95IteLxomM=
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 stream-browserify@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npm.taobao.org/stream-browserify/download/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
-  integrity sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
+  integrity sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
 stream-http@^2.7.2:
   version "2.8.3"
-  resolved "https://registry.npm.taobao.org/stream-http/download/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
-  integrity sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -713,55 +720,55 @@ stream-http@^2.7.2:
 
 string_decoder@^1.0.0:
   version "1.3.0"
-  resolved "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
 timers-browserify@^2.0.4:
   version "2.0.11"
-  resolved "https://registry.npm.taobao.org/timers-browserify/download/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
-  integrity sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
+  integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
   dependencies:
     setimmediate "^1.0.4"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/to-arraybuffer/download/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
 tty-browserify@0.0.0:
   version "0.0.0"
-  resolved "https://registry.npm.taobao.org/tty-browserify/download/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+  resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
 ultron@~1.1.0:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/ultron/download/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-  integrity sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
-union@~0.4.3:
-  version "0.4.6"
-  resolved "https://registry.npm.taobao.org/union/download/union-0.4.6.tgz#198fbdaeba254e788b0efcb630bc11f24a2959e0"
-  integrity sha1-GY+9rrolTniLDvy2MLwR8kopWeA=
+union@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/union/-/union-0.5.0.tgz#b2c11be84f60538537b846edb9ba266ba0090075"
+  integrity sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==
   dependencies:
-    qs "~2.3.3"
+    qs "^6.4.0"
 
 url-join@^2.0.5:
   version "2.0.5"
-  resolved "https://registry.npm.taobao.org/url-join/download/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
   integrity sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=
 
 url@^0.11.0:
   version "0.11.0"
-  resolved "https://registry.npm.taobao.org/url/download/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
   dependencies:
     punycode "1.3.2"
@@ -769,57 +776,55 @@ url@^0.11.0:
 
 util-deprecate@~1.0.1:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/util-deprecate/download/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util@0.10.3:
   version "0.10.3"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
 util@^0.11.0:
   version "0.11.1"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
-  integrity sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
 
 vm-browserify@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.npm.taobao.org/vm-browserify/download/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
-  integrity sha1-vXbWojMj4sqP+hICjcBFWcdfkBk=
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
+  integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
 which@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.npm.taobao.org/which/download/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 wordwrap@~0.0.2:
   version "0.0.3"
-  resolved "https://registry.npm.taobao.org/wordwrap/download/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
   integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
 ws@^3.0.0:
   version "3.3.3"
-  resolved "https://registry.npm.taobao.org/ws/download/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  integrity sha1-8c+E/i1ekB686U767OeF8YeiKPI=
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.npm.taobao.org/ws/download/ws-7.2.0.tgz#422eda8c02a4b5dba7744ba66eebbd84bcef0ec7"
-  integrity sha1-Qi7ajAKktdundEumbuu9hLzvDsc=
-  dependencies:
-    async-limiter "^1.0.0"
+ws@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
+  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
 
 xtend@^4.0.0:
   version "4.0.2"
-  resolved "https://registry.npm.taobao.org/xtend/download/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
-  integrity sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
Previous `cursor` is attached to component and `cursor->` was used to branching states, for convenience, e.g. `(cursor-> "xxx-id" comp-task states p1 p2)`. It's useful but has some limitations in building plugins with states since `cursor` is coupled deeply with component.

Now new syntax is proposed `(comp-task (>> states "xxx-id") p1 p2)`, which is a little better. The code has been experimented in Phlox(https://github.com/Quamolit/phlox/pull/41) and it has very similar ability to the previous solution. Plus, since now `cursor` is a user state value, so Respo users would have better control over states tree.

The downside is now a new field `:cursor` is attached to `states` along with `:data`. Users may find it a little annoying. However, it can be renamed to another variable easily since it's in user state. And other downsides might be the template code.

New version `0.12.0` has been started.
