### PR TITLE
add util function for simplifying states; alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Respo: A virtual DOM library in ClojureScript
 [![Respo](https://img.shields.io/clojars/v/respo/respo.svg)](https://clojars.org/respo/respo)
 
 ```clojure
-[respo "0.12.1-a1"]
+[respo "0.12.1-a2"]
 ```
 
 * Home http://respo-mvc.org

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Respo: A virtual DOM library in ClojureScript
 [![Respo](https://img.shields.io/clojars/v/respo/respo.svg)](https://clojars.org/respo/respo)
 
 ```clojure
-[respo "0.12.0"]
+[respo "0.12.1-a1"]
 ```
 
 * Home http://respo-mvc.org

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -210,12 +210,7 @@
                       |r $ {} (:type :expr) (:id |rkCmygfeOFRKb) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |r $ {} (:type :leaf) (:id |SJb4JeMx_FCKb) (:text |comp-todolist) (:by |root) (:at 1504774121421)
-                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718730076)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |rJGEJgGxuKRFZ) (:text |states) (:by |rJoDgvdeG) (:at 1584718729784)
-                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718731141) (:text |>>) (:id |ISElzMlt1f)
-                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718737043) (:text |:todolist) (:id |oP7XD2rx5)
-                            :id |XDzkqmpzT
+                          |v $ {} (:type :leaf) (:id |rJGEJgGxuKRFZ) (:text |states) (:by |rJoDgvdeG) (:at 1584718729784)
                           |x $ {} (:type :expr) (:id |S1RlBXcCb) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |HyV41lzeuKCtW) (:text |:tasks) (:by |root) (:at 1504774121421)
@@ -1661,6 +1656,17 @@
                     |j $ {} (:type :leaf) (:id |rkMPbxMl_KRFW) (:text |clojure.string) (:by |root) (:at 1504774121421)
                     |r $ {} (:type :leaf) (:id |SkQvbgGgOtRYW) (:text |:as) (:by |root) (:at 1504774121421)
                     |v $ {} (:type :leaf) (:id |Bk4vbxfxOFCKb) (:text |string) (:by |root) (:at 1504774121421)
+                |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871894046)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871894046) (:text |[]) (:id |0mDVXF_yNI)
+                    |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871894046) (:text |respo.cursor) (:id |zUUOobJ6Rh)
+                    |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871894046) (:text |:refer) (:id |Q5iGQ1KDEB)
+                    |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871894046)
+                      :data $ {}
+                        |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871894046) (:text |[]) (:id |qCV39iwqLk)
+                        |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871894046) (:text |updater-states) (:id |whnBHnf6eM)
+                      :id |o2SYOcdCc4
+                  :id |4HtvHnL1W0
         :defs $ {}
           |updater $ {} (:type :expr) (:id |SJaDbeMxOKAY-) (:by nil) (:at 1504774121421)
             :data $ {}
@@ -1915,44 +1921,12 @@
                   |r $ {} (:type :expr) (:id |S14tbezeuFCKW) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |HkHKZlzldFCYb) (:text |:states) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719281795)
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871897159)
                         :data $ {}
-                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719302329)
-                            :data $ {}
-                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719304502) (:text |assoc-in) (:id |l02JsLTi7r)
-                              |L $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719307293) (:text |store) (:id |brSNOSBVi)
-                              |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719308706)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719309808) (:text |concat) (:id |BR1lID9d8B)
-                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719314018)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719313746) (:text |[]) (:id |6MOBpGeLaG)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719315187) (:text |:states) (:id |IiwsJoTlH)
-                                    :id |QXBJpeW9_X
-                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584720021464)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720021464) (:text |[]) (:id |WwLoecb2QN)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720021464) (:text |:data) (:id |RCLhbCJLN6)
-                                    :id |rDMUTOeVFO
-                                  |n $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720024620) (:text |cursor) (:id |ALEP1pX4U2)
-                                :id |93m25QYs8c
-                              |h $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719332522) (:text |new-state) (:id |OYTbB_Mi0)
-                            :id |CxgPWiu1h2
-                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719283402) (:text |let) (:id |eGVwNOn-R)
-                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719283638)
-                            :data $ {}
-                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719283851)
-                                :data $ {}
-                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584719287121)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719284014) (:text |[]) (:id |mL2a52JhPv)
-                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719288288) (:text |cursor) (:id |W8PyCjY3NX)
-                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719293770) (:text |new-state) (:id |-cSCygN5IU)
-                                    :id |9ELfWGgok
-                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584719298030) (:text |op-data) (:id |sa_-pEQZB)
-                                :id |iAjFXXTh_u
-                            :id |2vLlZTdipJ
-                        :id |m6XwoLiTL
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871897554) (:text |updater-states) (:id |EZTH_BxM7leaf)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871899631) (:text |store) (:id |cBokux5Y9)
+                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871901297) (:text |op-data) (:id |yXZJcNOwkv)
+                        :id |EZTH_BxM7
                   |y $ {} (:type :expr) (:id |rkT3ZgzlOYRKZ) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |Bk0nZxfedKCFW) (:text |:clear) (:by |root) (:at 1504774121421)
@@ -2390,52 +2364,29 @@
                   |r $ {} (:type :leaf) (:id |ByOfWeuKAFb) (:text |op) (:by |root) (:at 1504774121421)
                   |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720061550) (:text |op-data) (:id |hyWaq1V-N)
                   |L $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584720208804) (:text |;) (:id |zNr_JsfkXh)
-              |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718843689)
+              |x $ {} (:type :expr) (:id |HkFz-ldYAFb) (:by nil) (:at 1504774121421)
                 :data $ {}
-                  |T $ {} (:type :expr) (:id |HkFz-ldYAFb) (:by nil) (:at 1504774121421)
+                  |T $ {} (:type :leaf) (:id |rJ9fZg_tRtZ) (:text |let) (:by |root) (:at 1504774121421)
+                  |j $ {} (:type :expr) (:id |H1if-guKAKZ) (:by nil) (:at 1504774121421)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:id |rJ9fZg_tRtZ) (:text |let) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :expr) (:id |H1if-guKAKZ) (:by nil) (:at 1504774121421)
+                      |j $ {} (:type :expr) (:id |rkgQZl_KCYW) (:by nil) (:at 1504774121421)
                         :data $ {}
-                          |T $ {} (:type :expr) (:id |SJnf-eOYCKZ) (:by nil) (:at 1504774121421)
+                          |T $ {} (:type :leaf) (:id |BkZX-gOKAtW) (:text |store) (:by |root) (:at 1504774121421)
+                          |j $ {} (:type :expr) (:id |SyfXZlOYCK-) (:by nil) (:at 1504774121421)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:id |By6f-lOYRFZ) (:text |op-id) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:id |SyCGbg_KAtb) (:by nil) (:at 1504774121421)
+                              |T $ {} (:type :leaf) (:id |rk7mWluKRK-) (:text |updater) (:by |root) (:at 1504774121421)
+                              |j $ {} (:type :leaf) (:id |Hk4XbldKRtW) (:text |@*store) (:by |root) (:at 1504774121421)
+                              |r $ {} (:type :leaf) (:id |B1BQWguKRtb) (:text |op) (:by |root) (:at 1504774121421)
+                              |v $ {} (:type :leaf) (:id |HJUm-xdtCYZ) (:text |op-data) (:by |root) (:at 1504774121421)
+                              |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871619734)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:id |ByJX-xdtRFW) (:text |get-id!) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :expr) (:id |rkgQZl_KCYW) (:by nil) (:at 1504774121421)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:id |BkZX-gOKAtW) (:text |store) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:id |SyfXZlOYCK-) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:id |rk7mWluKRK-) (:text |updater) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :leaf) (:id |Hk4XbldKRtW) (:text |@*store) (:by |root) (:at 1504774121421)
-                                  |r $ {} (:type :leaf) (:id |B1BQWguKRtb) (:text |op) (:by |root) (:at 1504774121421)
-                                  |v $ {} (:type :leaf) (:id |HJUm-xdtCYZ) (:text |op-data) (:by |root) (:at 1504774121421)
-                                  |x $ {} (:type :leaf) (:id |SkvQZl_K0YW) (:text |op-id) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :expr) (:id |r1_QbxdFRY-) (:by nil) (:at 1504774121421)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:id |SkYm-lOKAtb) (:text |reset!) (:by |root) (:at 1504774121421)
-                          |j $ {} (:type :leaf) (:id |B19mWe_YAKZ) (:text |*store) (:by |root) (:at 1504774121421)
-                          |r $ {} (:type :leaf) (:id |ByiX-eOFRKb) (:text |store) (:by |root) (:at 1504774121421)
-                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718846122) (:text |if) (:id |rwCjbrep9i)
-                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718846341)
+                                  |T $ {} (:type :leaf) (:id |SkvQZl_K0YW) (:text |get-id!) (:by |rJoDgvdeG) (:at 1584871619101)
+                                :id |ASugDCpDgK
+                  |r $ {} (:type :expr) (:id |r1_QbxdFRY-) (:by nil) (:at 1504774121421)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718847761) (:text |vector?) (:id |e2kWuNqsAy)
-                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718848314) (:text |op) (:id |iDmLrFqz0f)
-                    :id |7rdYnKFiv4
-                  |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718851481)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718853699) (:text |recur) (:id |Dii4pQIwH9leaf)
-                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718857610) (:text |:states) (:id |vyPf5DcgTP)
-                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718858433)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718858662) (:text |[]) (:id |jJsI95oC9)
-                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718859744) (:text |op) (:id |cnh-B1xHb4)
-                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718863792) (:text |op-data) (:id |HiMr8pqSj)
-                        :id |5HV7o9OKLN
-                    :id |Dii4pQIwH9
-                :id |-QS2jDfwiR
+                      |T $ {} (:type :leaf) (:id |SkYm-lOKAtb) (:text |reset!) (:by |root) (:at 1504774121421)
+                      |j $ {} (:type :leaf) (:id |B19mWe_YAKZ) (:text |*store) (:by |root) (:at 1504774121421)
+                      |r $ {} (:type :leaf) (:id |ByiX-eOFRKb) (:text |store) (:by |root) (:at 1504774121421)
           |handle-ssr! $ {} (:type :expr) (:by |root) (:at 1529814786924) (:id |ByeiWko2-Q)
             :data $ {}
               |T $ {} (:type :leaf) (:by |root) (:at 1529814786924) (:text |defn) (:id |HybiWyi2Wm)
@@ -5752,6 +5703,50 @@
               |j $ {} (:type :leaf) (:text |add-element) (:id |HkfJ7Yf5zf) (:by |root) (:at 1513920790595)
               |r $ {} (:type :leaf) (:text |0) (:id |rJ_4FfqGf) (:by |root) (:at 1513920815969)
         :proc $ {} (:type :expr) (:id |SJm20_G9fz) (:by |root) (:at 1513920723777) (:data $ {})
+      |respo.cursor $ {}
+        :ns $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871828389)
+          :data $ {}
+            |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871828389) (:text |ns) (:id |02WTQGWO3d)
+            |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871828389) (:text |respo.cursor) (:id |35c-rVGync)
+          :id |BYvf15I29H
+        :defs $ {}
+          |updater-states $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871832107)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871832107) (:text |defn) (:id |s2r3FixJ7N)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871832107) (:text |updater-states) (:id |Rua2PQZo8H)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871832107)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871837564) (:text |store) (:id |ZwR9oMPxe)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871839767)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871843294) (:text |[]) (:id |A75mWtPzIW)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871867563) (:text |cursor) (:id |cn8VhgsyPg)
+                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871872130) (:text |new-state) (:id |DPUYIChPx)
+                    :id |vJW8o0k_x
+                :id |qc2kdC09vg
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871847797)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872093061) (:text |assoc-in) (:id |q_CJ9A3QUgleaf)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871855179) (:text |store) (:id |1Rt8vtFTs)
+                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871857834)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871859467) (:text |concat) (:id |Y-uuaAygS_)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871859709)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871859893) (:text |[]) (:id |dAJHXozeln)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871863170) (:text |:states) (:id |TiJ-sNcQJJ)
+                        :id |I3mwtm8I6O
+                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871878400) (:text |cursor) (:id |Tph4DxhB9W)
+                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871879289)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871879508) (:text |[]) (:id |vuNSG-cwpx)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871880620) (:text |:data) (:id |Ut0_rilOhV)
+                        :id |2eMxtRLpm
+                    :id |3nGSb4QpDv
+                  |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871883571) (:text |new-state) (:id |qoUtcNaxq1)
+                :id |q_CJ9A3QUg
+            :id |gyw45KT_qe
+        :proc $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871828389) (:data $ {}) (:id |pN4ePZN3IM)
       |respo.render.patch $ {}
         :ns $ {} (:type :expr) (:id |SkRBylzeOY0KZ) (:by nil) (:at 1504774121421)
           :data $ {}
@@ -6907,7 +6902,7 @@
                           |T $ {} (:type :expr) (:id |rk3Mf45bAZ) (:by |root) (:at 1509168137711)
                             :data $ {}
                               |j $ {} (:type :leaf) (:text |x) (:id |HkRzME9W0b) (:by |root) (:at 1509168137711)
-                              |r $ {} (:type :leaf) (:text |200) (:id |BkkeGzV5WAW) (:by |root) (:at 1509168137711)
+                              |r $ {} (:type :leaf) (:text |200) (:id |BkkeGzV5WAW) (:by |rJoDgvdeG) (:at 1584872990408)
                       |r $ {} (:type :expr) (:id |ByxeGMNcbAb) (:by |root) (:at 1509168137711)
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |dispatch!) (:id |r1WeMzV5ZRZ) (:by |root) (:at 1509168137711)
@@ -7018,7 +7013,7 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:text |count) (:id |B1sNBcZRW) (:by |root) (:at 1509168435203)
                                   |j $ {} (:type :leaf) (:text |acc) (:id |Sy6Nrc-0b) (:by |root) (:at 1509168438004)
-                              |T $ {} (:type :leaf) (:text |40) (:id |rJWNr4cWAW) (:by |rJoDgvdeG) (:at 1571935799379)
+                              |T $ {} (:type :leaf) (:text |40) (:id |rJWNr4cWAW) (:by |rJoDgvdeG) (:at 1584872987926)
                           |T $ {} (:type :expr) (:id |Hyea4NqWRZ) (:by |root) (:at 1509168181449)
                             :data $ {}
                               |T $ {} (:type :leaf) (:text |js/setTimeout) (:id |Hyea4NqWRZleaf) (:by |root) (:at 1509168183634)
@@ -7089,11 +7084,19 @@
                       |D $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718933236)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718934262) (:text |cursor) (:id |yPhdU91iCleaf)
-                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718934490)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872700149)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718936300) (:text |:cursor) (:id |BDEjdcb28y)
-                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718936996) (:text |states) (:id |GuJkiGOlJD)
-                            :id |nBDoehdq1Z
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584718934490)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718936300) (:text |:cursor) (:id |BDEjdcb28y)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584718936996) (:text |states) (:id |GuJkiGOlJD)
+                                :id |nBDoehdq1Z
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872700685) (:text |or) (:id |SPpe07d68w)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872701364)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872702117) (:text |[]) (:id |L5Uy3rLgd)
+                                :id |_n8E2BLJWo
+                            :id |dCsP7mW2E
                         :id |yPhdU91iC
                   |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571574450097) (:id |u8cLCYV5i)
                     :data $ {}
@@ -9046,6 +9049,52 @@
                                       |T $ {} (:type :leaf) (:id |HkCBGGgOF0tZ) (:text |:event) (:by |root) (:at 1504774121421)
                                       |j $ {} (:type :leaf) (:id |H11UMMxdK0F-) (:text |target-element) (:by |root) (:at 1504774121421)
                                   |r $ {} (:type :leaf) (:id |ByeLzGldt0K-) (:text |event-name) (:by |root) (:at 1504774121421)
+                          |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871534908)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871546817) (:text |dispatch-wrap) (:id |1IO0Oce-Qnleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871547656)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871547971) (:text |fn) (:id |IVnOY72Tu)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871548221)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871548803) (:text |op) (:id |SG6A19Jj1k)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871557596) (:text |data) (:id |x9jgV1x76)
+                                    :id |qXmOv0zcI
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872185338)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871558547)
+                                        :data $ {}
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871560410)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871562129) (:text |vector?) (:id |vE0n9opsaV)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871563045) (:text |op) (:id |YqJdRvvy-B)
+                                            :id |-qmpe2mEj
+                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871563843)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871566681) (:text |dispatch!) (:id |UejRHLxgNeleaf)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871571390) (:text |:states) (:id |Ml-6w5tHl)
+                                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871573638)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871573986) (:text |[]) (:id |TAZiV7vqAL)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871574651) (:text |op) (:id |2DJxWZ4x9)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871575952) (:text |data) (:id |_iuEV0nXAB)
+                                                :id |EF_VJlmcE5
+                                            :id |UejRHLxgNe
+                                        :id |zZH9hEQYI9
+                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872332376) (:text |cond) (:id |W0ZZjXI83)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872190627)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192240) (:text |:else) (:id |lnLbopL2xleaf)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584872192690)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |dispatch!) (:id |BZfvgGn2Oj)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |op) (:id |YuVNmJIl1G)
+                                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584872192690) (:text |data) (:id |jS6HFoTcbg)
+                                            :id |3-RSFBsszv
+                                        :id |lnLbopL2x
+                                    :id |kIeHDlFG6
+                                :id |1RbNRq4o58
+                            :id |1IO0Oce-Qn
                       |r $ {} (:type :expr) (:id |HkqvzMgdKAFW) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:id |r1jwffxdKRF-) (:text |if) (:by |root) (:at 1504774121421)
@@ -9067,7 +9116,7 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:id |r1u_MMxdKAYZ) (:text |target-listener) (:by |root) (:at 1504774121421)
                                   |j $ {} (:type :leaf) (:id |SyKuMGg_t0K-) (:text |simple-event) (:by |root) (:at 1504774121421)
-                                  |r $ {} (:type :leaf) (:id |By5dGfe_YAF-) (:text |dispatch!) (:by |root) (:at 1504774121421)
+                                  |r $ {} (:type :leaf) (:id |By5dGfe_YAF-) (:text |dispatch-wrap) (:by |rJoDgvdeG) (:at 1584871591793)
                           |v $ {} (:type :expr) (:id |Hk2uMzluK0KW) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:id |Hy6_zGxOY0t-) (:text |;) (:by |root) (:at 1504774121421)
@@ -9344,9 +9393,6 @@
                   |r $ {} (:type :expr) (:id |rJc82GgdYCFZ) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:id |HJiLnfxOF0Kb) (:text |[]) (:by |root) (:at 1504774121421)
-                  |v $ {} (:type :expr) (:id |BJhU3GgdKRYZ) (:by nil) (:at 1504774121421)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:id |HyT82MxOYRY-) (:text |[]) (:by |root) (:at 1504774121421)
                   |y $ {} (:type :leaf) (:id |B1gDnfxdY0tW) (:text |old-element) (:by |root) (:at 1504774121421)
           |render-children $ {} (:type :expr) (:id |ry-v3feut0K-) (:by nil) (:at 1504774121421)
             :data $ {}
@@ -9356,7 +9402,6 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:id |rkBDhMxdKCKZ) (:text |children) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |r1Uw3GeOYCtZ) (:text |coord) (:by |root) (:at 1504774121421)
-                  |r $ {} (:type :leaf) (:id |H1Dwhfe_tRtZ) (:text |comp-coord) (:by |root) (:at 1504774121421)
                   |x $ {} (:type :leaf) (:id |BJYvnzgdYAK-) (:text |old-children) (:by |root) (:at 1504774121421)
               |v $ {} (:type :expr) (:id |By5v3MxdFRYW) (:by nil) (:at 1504774121421)
                 :data $ {}
@@ -9453,7 +9498,6 @@
                                                       |T $ {} (:type :leaf) (:id |Hkl3hMldK0Yb) (:text |conj) (:by |root) (:at 1504774121421)
                                                       |j $ {} (:type :leaf) (:id |HkWnhzx_YRK-) (:text |coord) (:by |root) (:at 1504774121421)
                                                       |r $ {} (:type :leaf) (:id |rkfn2GxdKCKW) (:text |k) (:by |root) (:at 1504774121421)
-                                                  |v $ {} (:type :leaf) (:id |rJm23zeOtAK-) (:text |comp-coord) (:by |root) (:at 1504774121421)
                                                   |y $ {} (:type :leaf) (:id |S1S22feOKAtZ) (:text |old-child) (:by |root) (:at 1504774121421)
                                               |v $ {} (:type :leaf) (:id |By8nnMgutCY-) (:text |nil) (:by |root) (:at 1504774121421)
           |render-component $ {} (:type :expr) (:id |SyNaiGxdKRFb) (:by nil) (:at 1504774121421)
@@ -9648,7 +9692,6 @@
                                               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |render-markup) (:id |uxtUCos_Xj)
                                               |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |markup-tree) (:id |Voj2JzWV5C)
                                               |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |new-coord) (:id |wIToF1TDyK)
-                                              |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |new-coord) (:id |ahuaMUZuze)
                                               |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571575501498) (:id |VhpLYN5TrJ)
                                                 :data $ {}
                                                   |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575501498) (:text |:tree) (:id |7HoypfTsd0)
@@ -9725,7 +9768,6 @@
                                                   |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |render-markup) (:id |HRzN0lJJ-5)
                                                   |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575595432) (:text |node-tree) (:id |D0k2yY3_JT)
                                                   |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |new-coord) (:id |59wMVC9z1R)
-                                                  |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |new-coord) (:id |sRJ55uYGeB)
                                                   |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571575509792) (:id |ewb-2t1sX4)
                                                     :data $ {}
                                                       |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571575509792) (:text |:tree) (:id |IURMPpvDPJ)
@@ -9758,7 +9800,6 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:id |rJjhhMgutRFW) (:text |markup) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |BJn23Me_K0F-) (:text |coord) (:by |root) (:at 1504774121421)
-                  |r $ {} (:type :leaf) (:id |SkT33GgOYAKZ) (:text |comp-coord) (:by |root) (:at 1504774121421)
                   |x $ {} (:type :leaf) (:id |r1ya2GguFRFW) (:text |old-element) (:by |root) (:at 1504774121421)
               |v $ {} (:type :expr) (:id |Skxp3GguYAK-) (:by nil) (:at 1504774121421)
                 :data $ {}
@@ -9780,7 +9821,6 @@
                               |T $ {} (:type :leaf) (:id |r1sahzl_FAKW) (:text |render-children) (:by |root) (:at 1504774121421)
                               |j $ {} (:type :leaf) (:id |rJ3p2zgdFAFW) (:text |children) (:by |root) (:at 1504774121421)
                               |r $ {} (:type :leaf) (:id |SJa6nGedF0FZ) (:text |coord) (:by |root) (:at 1504774121421)
-                              |v $ {} (:type :leaf) (:id |rJRa2Gx_FRKb) (:text |comp-coord) (:by |root) (:at 1504774121421)
                               |y $ {} (:type :expr) (:id |B1l0hGxOKCFZ) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:id |By-AnGxutRFb) (:text |:children) (:by |root) (:at 1504774121421)
@@ -9809,7 +9849,6 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:id |rk2kaGe_F0FW) (:text |markup) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |H161azg_FRtb) (:text |coord) (:by |root) (:at 1504774121421)
-                  |r $ {} (:type :leaf) (:id |BkAypzxdFCFb) (:text |comp-coord) (:by |root) (:at 1505325712568)
                   |x $ {} (:type :leaf) (:id |BJleafl_F0F-) (:text |old-element) (:by |root) (:at 1504774121421)
               |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571933402610) (:id |75yC3HR8o)
                 :data $ {}
@@ -9877,7 +9916,6 @@
                           |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |render-element) (:id |R40iCmlJsr)
                           |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |markup) (:id |tgyZRY0Pqo)
                           |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |coord) (:id |O4_YApW2zU)
-                          |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |comp-coord) (:id |bKwJotpF6b)
                           |y $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |old-element) (:id |V8tGCOcb69)
                   |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571933408387) (:id |lbgcsEmHN3)
                     :data $ {}
@@ -9904,7 +9942,6 @@
                           |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |render-element) (:id |R40iCmlJsr)
                           |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |markup) (:id |tgyZRY0Pqo)
                           |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |coord) (:id |O4_YApW2zU)
-                          |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571933414526) (:text |comp-coord) (:id |bKwJotpF6b)
                           |y $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1572086253273) (:text |nil) (:id |V8tGCOcb69)
                   |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571933416946) (:id |fp9rJPCXv)
                     :data $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1664,7 +1664,7 @@
                     |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871894046)
                       :data $ {}
                         |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871894046) (:text |[]) (:id |qCV39iwqLk)
-                        |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871894046) (:text |updater-states) (:id |whnBHnf6eM)
+                        |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584874768040) (:text |update-states) (:id |whnBHnf6eM)
                       :id |o2SYOcdCc4
                   :id |4HtvHnL1W0
         :defs $ {}
@@ -1923,7 +1923,7 @@
                       |T $ {} (:type :leaf) (:id |HkHKZlzldFCYb) (:text |:states) (:by |root) (:at 1504774121421)
                       |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871897159)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871897554) (:text |updater-states) (:id |EZTH_BxM7leaf)
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584874759470) (:text |update-states) (:id |EZTH_BxM7leaf)
                           |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871899631) (:text |store) (:id |cBokux5Y9)
                           |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871901297) (:text |op-data) (:id |yXZJcNOwkv)
                         :id |EZTH_BxM7
@@ -5710,10 +5710,10 @@
             |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871828389) (:text |respo.cursor) (:id |35c-rVGync)
           :id |BYvf15I29H
         :defs $ {}
-          |updater-states $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871832107)
+          |update-states $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871832107)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871832107) (:text |defn) (:id |s2r3FixJ7N)
-              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871832107) (:text |updater-states) (:id |Rua2PQZo8H)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871832107) (:text |update-states) (:id |Rua2PQZo8H)
               |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1584871832107)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1584871837564) (:text |store) (:id |ZwR9oMPxe)

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.12.0"
+{:version "0.12.1-a1"
  :group-id "respo"
  :artifact-id "respo"
  :skip-tag true

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.12.1-a1"
+{:version "0.12.1-a2"
  :group-id "respo"
  :artifact-id "respo"
  :skip-tag true

--- a/src/respo/app/comp/container.cljs
+++ b/src/respo/app/comp/container.cljs
@@ -13,5 +13,5 @@
  (let [states (:states store)]
    (div
     {:style style-global}
-    (comp-todolist (>> states :todolist) (:tasks store))
+    (comp-todolist states (:tasks store))
     (div {:style style-states} (<> (str "states: " (pr-str (:states store))))))))

--- a/src/respo/app/comp/todolist.cljs
+++ b/src/respo/app/comp/todolist.cljs
@@ -57,7 +57,7 @@
 (defcomp
  comp-todolist
  (states tasks)
- (let [cursor (:cursor states), state (or (:data states) initial-state)]
+ (let [cursor (or (:cursor states) []), state (or (:data states) initial-state)]
    [(effect-focus)
     (div
      {:style style-root}

--- a/src/respo/app/core.cljs
+++ b/src/respo/app/core.cljs
@@ -11,9 +11,7 @@
 
 (defn dispatch! [op op-data]
   (comment println op op-data)
-  (if (vector? op)
-    (recur :states [op op-data])
-    (let [op-id (get-id!), store (updater @*store op op-data op-id)] (reset! *store store))))
+  (let [store (updater @*store op op-data (get-id!))] (reset! *store store)))
 
 (defn handle-ssr! [mount-target]
   (realize-ssr! mount-target (comp-container @*store) dispatch!))

--- a/src/respo/app/updater.cljs
+++ b/src/respo/app/updater.cljs
@@ -1,12 +1,11 @@
 
-(ns respo.app.updater (:require [clojure.string :as string]))
+(ns respo.app.updater
+  (:require [clojure.string :as string] [respo.cursor :refer [updater-states]]))
 
 (defn updater [store op-type op-data op-id]
   (comment println (pr-str store) (pr-str op-type) (pr-str op-data))
   (case op-type
-    :states
-      (let [[cursor new-state] op-data]
-        (assoc-in store (concat [:states] cursor [:data]) new-state))
+    :states (updater-states store op-data)
     :add
       (update store :tasks (fn [tasks] (conj tasks {:text op-data, :id op-id, :done? false})))
     :remove

--- a/src/respo/app/updater.cljs
+++ b/src/respo/app/updater.cljs
@@ -1,11 +1,11 @@
 
 (ns respo.app.updater
-  (:require [clojure.string :as string] [respo.cursor :refer [updater-states]]))
+  (:require [clojure.string :as string] [respo.cursor :refer [update-states]]))
 
 (defn updater [store op-type op-data op-id]
   (comment println (pr-str store) (pr-str op-type) (pr-str op-data))
   (case op-type
-    :states (updater-states store op-data)
+    :states (update-states store op-data)
     :add
       (update store :tasks (fn [tasks] (conj tasks {:text op-data, :id op-id, :done? false})))
     :remove

--- a/src/respo/controller/resolve.cljs
+++ b/src/respo/controller/resolve.cljs
@@ -32,9 +32,13 @@
 (defn build-deliver-event [*global-element dispatch!]
   (fn [coord event-name simple-event]
     (let [target-element (find-event-target @*global-element coord event-name)
-          target-listener (get (:event target-element) event-name)]
+          target-listener (get (:event target-element) event-name)
+          dispatch-wrap (fn [op data]
+                          (cond
+                            (vector? op) (dispatch! :states [op data])
+                            :else (dispatch! op data)))]
       (if (some? target-listener)
         (do
          (comment println "listener found:" coord event-name)
-         (target-listener simple-event dispatch!))
+         (target-listener simple-event dispatch-wrap))
         (comment println "found no listener:" coord event-name)))))

--- a/src/respo/cursor.cljs
+++ b/src/respo/cursor.cljs
@@ -1,5 +1,5 @@
 
 (ns respo.cursor )
 
-(defn updater-states [store [cursor new-state]]
+(defn update-states [store [cursor new-state]]
   (assoc-in store (concat [:states] cursor [:data]) new-state))

--- a/src/respo/cursor.cljs
+++ b/src/respo/cursor.cljs
@@ -1,0 +1,5 @@
+
+(ns respo.cursor )
+
+(defn updater-states [store [cursor new-state]]
+  (assoc-in store (concat [:states] cursor [:data]) new-state))

--- a/src/respo/render/expand.cljs
+++ b/src/respo/render/expand.cljs
@@ -13,24 +13,23 @@
 
 (declare render-markup)
 
-(defn render-markup [markup coord comp-coord old-element]
+(defn render-markup [markup coord old-element]
   (cond
     (and (component? markup) (component? old-element))
       (render-component markup coord old-element)
     (and (component? markup) (or (element? old-element) (nil? old-element)))
       (render-component markup coord nil)
-    (and (element? markup) (element? old-element))
-      (render-element markup coord comp-coord old-element)
+    (and (element? markup) (element? old-element)) (render-element markup coord old-element)
     (and (element? markup) (or (component? old-element) (nil? old-element)))
-      (render-element markup coord comp-coord nil)
+      (render-element markup coord nil)
     :else
       (do
        (js/console.log "Markup:" markup)
        (throw (js/Error. (str "expects component or element!"))))))
 
-(defn render-element [markup coord comp-coord old-element]
+(defn render-element [markup coord old-element]
   (let [children (:children markup)
-        child-elements (render-children children coord comp-coord (:children old-element))]
+        child-elements (render-children children coord (:children old-element))]
     (comment js/console.log "children should have order:" children child-elements markup)
     (assoc markup :coord coord :children child-elements)))
 
@@ -55,7 +54,7 @@
           (merge
            markup
            {:coord coord,
-            :tree (render-markup markup-tree new-coord new-coord (:tree old-element)),
+            :tree (render-markup markup-tree new-coord (:tree old-element)),
             :local local})
         (sequential? markup-tree)
           (let [node-tree (filter-first (fn [x] (or (component? x) (element? x))) markup-tree)
@@ -63,12 +62,12 @@
             (merge
              markup
              {:coord coord,
-              :tree (render-markup node-tree new-coord new-coord (:tree old-element)),
+              :tree (render-markup node-tree new-coord (:tree old-element)),
               :effects effects-list,
               :local local}))
         :else (do (js/console.warn "Unknown markup:" markup) nil)))))
 
-(defn render-children [children coord comp-coord old-children]
+(defn render-children [children coord old-children]
   (comment println "render children:" children)
   (let [mapped-cache (into {} old-children)]
     (doall
@@ -82,7 +81,7 @@
                 (do (println "old child:" coord (some? old-child))))
                [k
                 (if (some? child-element)
-                  (render-markup child-element (conj coord k) comp-coord old-child)
+                  (render-markup child-element (conj coord k) old-child)
                   nil)])))))))
 
-(defn render-app [markup old-element] (render-markup markup [] [] old-element))
+(defn render-app [markup old-element] (render-markup markup [] old-element))


### PR DESCRIPTION
Added `respo.cursor/update-states` for updating store. Transformed `(dispatch! cursor...` from inside the library.
