### PR TITLE
Initial work on respo.caches and defplugin

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -177,6 +177,28 @@
                       :data $ {}
                         |T $ {} (:type :leaf) (:id |r1yMkeGxOtCKZ) (:text |[]) (:by |root) (:at 1504774121421)
                         |j $ {} (:type :leaf) (:id |Sylf1ezl_FCt-) (:text |comp-todolist) (:by |root) (:at 1504774121421)
+                |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129940852)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129940852) (:text |[]) (:id |KGXPbOpZe4)
+                    |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129940852) (:text |respo.app.comp.caches) (:id |uvdbWCogfu)
+                    |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129940852) (:text |:refer) (:id |ryE1EQhSLv)
+                    |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129940852)
+                      :data $ {}
+                        |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129940852) (:text |[]) (:id |OJuBS3SBsu)
+                        |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129940852) (:text |comp-caches) (:id |2x93R3zNfx)
+                      :id |iaVXDBu79n
+                  :id |XkgpdA0V6Q
+                |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134715191)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134715502) (:text |[]) (:id |0BRsZ37ZFleaf)
+                    |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134718074) (:text |respo.comp.space) (:id |KKIKN7G7Mb)
+                    |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134718793) (:text |:refer) (:id |-EI6UkHvCK)
+                    |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134718980)
+                      :data $ {}
+                        |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134719112) (:text |[]) (:id |1H9k47k_6h)
+                        |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134722022) (:text |=<) (:id |5ekECO7wBO)
+                      :id |iTDtJcfgPK
+                  :id |0BRsZ37ZF
         :defs $ {}
           |comp-container $ {} (:type :expr) (:id |Bk9zklMluK0KZ) (:by nil) (:at 1504774121421)
             :data $ {}
@@ -239,6 +261,22 @@
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:id |SJQBJlMxOFCYZ) (:text |:states) (:by |root) (:at 1505327099898)
                                           |j $ {} (:type :leaf) (:id |BkErJlfe_tRYb) (:text |store) (:by |root) (:at 1504774121421)
+                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134765255)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134765255) (:text |=<) (:id |RbN-_YkAXB)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134765255) (:text |nil) (:id |JmO0sj0X2B)
+                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134765255) (:text |40) (:id |5ltd5n2EpV)
+                        :id |g47IUFEgtv
+                      |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134769660)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134769660) (:text |comp-caches) (:id |6-4_P7Sodf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134769660)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134769660) (:text |>>) (:id |5A7GVaM3m1)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134769660) (:text |states) (:id |WQA0fv_kjB)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134769660) (:text |:caches) (:id |SdrSDZ1pli)
+                            :id |NhORryvq_w
+                        :id |JyLDzCLqx3
           |style-global $ {} (:type :expr) (:id |SJIrJlfgdtCYW) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:id |BkwH1efl_tAKW) (:text |def) (:by |root) (:at 1504774121421)
@@ -5278,6 +5316,521 @@
                                               |v $ {} (:type :leaf) (:id |HJIIqfguKCYZ) (:text |old-follows) (:by |root) (:at 1504774121421)
                                               |x $ {} (:type :leaf) (:id |H1PUcfxdFRt-) (:text |new-follows) (:by |root) (:at 1504774121421)
         :proc $ {} (:type :expr) (:id |r1eEvMl_tCtb) (:by nil) (:at 1504774121421) (:data $ {})
+      |respo.caches $ {}
+        :ns $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127749755)
+          :data $ {}
+            |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127749755) (:text |ns) (:id |QwTT33AxAH)
+            |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127749755) (:text |respo.caches) (:id |v0oPt86Jq8)
+          :id |AwW0KKkP-Q
+        :defs $ {}
+          |*cache-states $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127760390)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127763601) (:text |defonce) (:id |BQKGZAKbR2)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127760390) (:text |*cache-states) (:id |ZNODkxpxfv)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127760390)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127765111) (:text |atom) (:id |IdIVaFsWp9)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127765785)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127766107) (:text |{}) (:id |h6gZEsr4j3)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127766370)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127906916) (:text |:loop) (:id |qkZLNnrl0H)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127770653) (:text |0) (:id |Q19BOejM7I)
+                        :id |HbqokZbAGb
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127772412)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127774465) (:text |:caches) (:id |M3BqDBFT6kleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127775692)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127776041) (:text |{}) (:id |e_Es9j2-0)
+                            :id |5CsTd__3xt
+                        :id |M3BqDBFT6k
+                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127777153)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127976610) (:text |:gc) (:id |ek0VxRWjkleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127813714)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127814041) (:text |{}) (:id |Ca3rn3GbD)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127814460)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127904506) (:text |:trigger-loop) (:id |ZMcXRuw2U)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135528216) (:text |100) (:id |MH48nAR3o)
+                                :id |bchdSxsbkk
+                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127888801)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592127938572) (:text |:elapse-loop) (:id |xFKguN7Buleaf)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135526323) (:text |50) (:id |R63EDt6by)
+                                :id |xFKguN7Bu
+                              |b $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592135469501)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135474892) (:text |:cold-duration) (:id |9zhkUY91Nileaf)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135520733) (:text |400) (:id |ucmePXz1bt)
+                                :id |9zhkUY91Ni
+                            :id |U4NkGEoqcG
+                        :id |ek0VxRWjk
+                    :id |c9cqPXO-83
+                :id |Fi0luevY9l
+            :id |qZj8D4Km8d
+          |new-loop! $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128082026)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128082026) (:text |defn) (:id |mm5LQHQY2t)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128082026) (:text |new-loop!) (:id |h02Q4KP1pl)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128082026) (:data $ {}) (:id |P6Om5JWka2)
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128087116)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128090121) (:text |swap!) (:id |gKVs69PLrleaf)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128094496) (:text |*cache-states) (:id |ALY__yiLI3)
+                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128104433) (:text |:loop) (:id |JqcAfXIvS)
+                  |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128105311) (:text |inc) (:id |LSJgAJhPdq)
+                  |n $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130168461) (:text |update) (:id |1gCZHtcmy)
+                :id |gKVs69PLr
+              |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128157521)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128159932) (:text |let) (:id |klKT6cM-bleaf)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128160418)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128160627)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128169996) (:text |loop-count) (:id |MLLn9wroEq)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128170264)
+                            :data $ {}
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128181780) (:text |@*cache-states) (:id |UPTUuCGgg3)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128234339) (:text |:loop) (:id |bb6AVjT9bg)
+                            :id |XTtogaBVB
+                        :id |FmVGLL8ILs
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592135433696)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135434734) (:text |gc) (:id |w6_ncSd3xleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592135435092)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135437478) (:text |@*cache-states) (:id |nyx8sAgmLq)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135440033) (:text |:gc) (:id |MCOnZ2lJFo)
+                            :id |V6tK3LiFF
+                        :id |w6_ncSd3x
+                    :id |W2vAQbXQm
+                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128182877)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128206945) (:text |when) (:id |DH8zOpqE-tleaf)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128214379)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128197676)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128184265)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129630811) (:text |rem) (:id |bX5iMVn2x6)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128189939) (:text |loop-count) (:id |3M5LNzQ93)
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128230468)
+                                    :data $ {}
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135444036) (:text |gc) (:id |7qMMeDNfLO)
+                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128254785) (:text |:trigger-loop) (:id |dy6nchQDi)
+                                    :id |kUi6fL61-k
+                                :id |BHnBfq_JB
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128199421) (:text |zero?) (:id |7SuKHaBKFw)
+                            :id |jdcN4R5XJ
+                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128216390) (:text |and) (:id |bC9Yzs-ew)
+                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128216962)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128218587) (:text |>) (:id |-Y2t9XSDY4)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128222024) (:text |loop-count) (:id |EygVfiSX4)
+                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592135496021)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135502109) (:text |gc) (:id |J6OC0robX)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135505160) (:text |:cold-duration) (:id |bYNmFU1nbC)
+                                :id |BA4ClDRu4m
+                            :id |MBhqV-hYkV
+                        :id |NTK7GYCHy
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128200585)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128204258) (:text |perform-gc!) (:id |FskZYBHyyleaf)
+                        :id |FskZYBHyy
+                    :id |DH8zOpqE-t
+                :id |klKT6cM-b
+            :id |loArdts6er
+          |perform-gc! $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128152087)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128152087) (:text |defn) (:id |k0XX5sqxON)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128152087) (:text |perform-gc!) (:id |dAAFLXT01a)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128152087) (:data $ {}) (:id |O38PTeykPy)
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134197302)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128285845)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134182949) (:text |println) (:id |_vM05YpRyleaf)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135381779) (:text "|\"[Respo Caches] Performed GC, from ") (:id |Gaf1hk6rO)
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134576395)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134578051) (:text |count) (:id |0XPw9N4rS)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134578573)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134628292) (:text |states-0) (:id |LPmgaj5jM)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134584756) (:text |:caches) (:id |EdL55pmes5)
+                            :id |hUQ_F4OA0P
+                        :id |LmyTCNWkF
+                      |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134588692) (:text "|\" to ") (:id |fsiIx3rp5t)
+                      |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134593644)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134594683) (:text |count) (:id |L7PnKyh5OI)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134605740)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134602823) (:text |@*cache-states) (:id |eY6t8X6Z_8)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134607514) (:text |:caches) (:id |kPfXwNGPzj)
+                            :id |bCBPnE7uzA
+                        :id |H1-fetEfe
+                    :id |_vM05YpRy
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134197917) (:text |let) (:id |Izrb0nqrhb)
+                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134198231)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134198396)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134209330) (:text |states-0) (:id |60uws58QBC)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134214934) (:text |@*cache-states) (:id |5S1XxHSbA7)
+                        :id |1QPOg1nB3N
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134347884)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134348182) (:text |gc) (:id |QQWeJuIZLsleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134348882)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134353333) (:text |states-0) (:id |K4xGn247yQ)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134357111) (:text |:gc) (:id |Rmc_GUbCDy)
+                            :id |67uAlAlPg7
+                        :id |QQWeJuIZLs
+                    :id |MI-LHFnei
+                  |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134224545)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134229174) (:text |swap!) (:id |uyJBlC0XDleaf)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134234292) (:text |*cache-states) (:id |OQDbB8pqL0)
+                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134622564) (:text |update) (:id |bUSwHhpC8)
+                      |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134242867) (:text |:caches) (:id |F50cXz9bDv)
+                      |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134243231)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134244324) (:text |fn) (:id |BmkuihEaDN)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134244635)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134245493) (:text |caches) (:id |saJRU5HeD0)
+                            :id |7rIWoWxxXM
+                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134246034)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134251214) (:text |->>) (:id |7umlzvDbYjleaf)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134255318) (:text |caches) (:id |DKH0Y7-nbC)
+                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134256703)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134665786) (:text |remove) (:id |vfBNHnOEP)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134257807)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134258154) (:text |fn) (:id |pDg4O7LkTO)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134258674)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134259861)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134260142) (:text |[]) (:id |yLUUS8alrp)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134261045) (:text |params) (:id |RZOzkI5pHF)
+                                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134265338) (:text |info) (:id |Hq3ocTvuw)
+                                            :id |7Ilx2zOFX
+                                        :id |N7fDbPiLa0
+                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134280972)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134286502) (:text |cond) (:id |hxwnyDFrYZleaf)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134286954)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134287116)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134311203) (:text |zero?) (:id |4gfCoRVSfH)
+                                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134304268)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134305245) (:text |info) (:id |mEcD5OrUS)
+                                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134654158) (:text |:hit-times) (:id |WS2DvgvbQ)
+                                                    :id |OiM9M52bw
+                                                :id |Q24FBKm38
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134668573) (:text |true) (:id |FmsBlGI77)
+                                            :id |9rzqvUi48Y
+                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134286954)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134287116)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134405040) (:text |>) (:id |4gfCoRVSfH)
+                                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134391551)
+                                                    :data $ {}
+                                                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134304268)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134305245) (:text |info) (:id |mEcD5OrUS)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134453838) (:text |:hit-loop) (:id |WS2DvgvbQ)
+                                                        :id |OiM9M52bw
+                                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134392114) (:text |-) (:id |Mp_hZ9Ycls)
+                                                      |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134395271)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134631736) (:text |states-0) (:id |bfBWjPJQX)
+                                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134530900) (:text |:loop) (:id |iIXwjLHcxe)
+                                                        :id |E7GseudRK
+                                                    :id |Nwq3O6-SmZ
+                                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134341911)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134359850) (:text |gc) (:id |qVgA8FPEX)
+                                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134388060) (:text |:elapse-loop) (:id |TIv03JJYJ)
+                                                    :id |BZ8OMDsLfM
+                                                :id |Q24FBKm38
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134670449) (:text |true) (:id |FmsBlGI77)
+                                            :id |czGKpELs4
+                                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134330285)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134331153) (:text |:else) (:id |UyLl0ODxsleaf)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134673184) (:text |false) (:id |CLzsd5dk7M)
+                                            :id |UyLl0ODxs
+                                        :id |hxwnyDFrYZ
+                                    :id |YCpBka4KTw
+                                :id |hIh-8izfYQ
+                              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134269503)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134272356) (:text |into) (:id |_RXQAsub-Sleaf)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134270584)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134270901) (:text |{}) (:id |Lp0kYfMxWj)
+                                    :id |soeLWfoMjW
+                                :id |_RXQAsub-S
+                            :id |7umlzvDbYj
+                        :id |SqZg9U5bB
+                    :id |uyJBlC0XD
+                :id |c7rpUocCk
+            :id |J4obk77XHz
+          |write-cache! $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128742326)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128742326) (:text |defn) (:id |YMMr9Zeg8m)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128742326) (:text |write-cache!) (:id |QgHE_mZimF)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128742326)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128749999) (:text |params) (:id |4Vemni1YqK)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128753189) (:text |value) (:id |lVtJr52r7)
+                :id |hSJB7miuGc
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128829579)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128754796)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130232052) (:text |swap!) (:id |1HNReBlkDSleaf)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128772311) (:text |*cache-states) (:id |3iL6x2T-ew)
+                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128773814) (:text |:caches) (:id |8LTSSDvxEf)
+                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128774118)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128775072) (:text |fn) (:id |pwPxo-W8Vj)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128775327)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128776130) (:text |caches) (:id |hSQvOaDpDx)
+                            :id |VN-CEmZAS7
+                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128777265)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128779446) (:text |if) (:id |MlTpbQoGHIleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128780059)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128781581) (:text |contains?) (:id |5QGevBaVIv)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128783638) (:text |caches) (:id |eTNv_4plr)
+                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128888597) (:text |params) (:id |nUASAFEeOO)
+                                :id |ddba7W83UU
+                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128796324)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128786248)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128911846) (:text |println) (:id |zY9sA_O6T)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135372259) (:text "|\"[Respo Caches] already exisits") (:id |g6CdKIIXn0)
+                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128906068) (:text |params) (:id |9Bw8-puqg)
+                                    :id |OOFG3Amhc
+                                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128796877) (:text |do) (:id |6fyfC5nV2j)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128797601)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128803332) (:text |update) (:id |sPrUvFt7U1leaf)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128810116) (:text |caches) (:id |XCbRSYCVY)
+                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128812548) (:text |params) (:id |xWPb_AIX-u)
+                                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128816641)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128816983) (:text |fn) (:id |HO7eSCSLEH)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128817569)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128818459) (:text |info) (:id |cIQTU3mkw)
+                                            :id |oqvQJSihoY
+                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128819459)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128822646) (:text |->) (:id |TK6PnD5Dnaleaf)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128823873) (:text |info) (:id |2Du6XQLcx)
+                                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128824585)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128827152) (:text |assoc) (:id |aDVJqCOVf)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128856972) (:text |:last-hit) (:id |0p0Giz-T7)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128859437) (:text |the-loop) (:id |S5T-x7EPEl)
+                                                :id |XJRoovZF3a
+                                              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128860663)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128863266) (:text |update) (:id |u6seQY2mOvleaf)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128867614) (:text |:hit-times) (:id |WjKuee0_OM)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128868808) (:text |inc) (:id |jr9uhej7x)
+                                                :id |u6seQY2mOv
+                                            :id |TK6PnD5Dna
+                                        :id |nZFcJeimnM
+                                    :id |sPrUvFt7U1
+                                :id |Z_dX156cO
+                              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128913352)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128927115) (:text |assoc) (:id |2n7PBYA7eleaf)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128922061) (:text |caches) (:id |-vTRcTe3Z)
+                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128924809) (:text |params) (:id |1wjWPuvsX)
+                                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128929060)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128929468) (:text |{}) (:id |8Id91ZdA3U)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128929736)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128931118) (:text |:value) (:id |FECskhQjQr)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128931834) (:text |value) (:id |HQ_dgD8tif)
+                                        :id |QfPbLEP_XI
+                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128932406)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128939291) (:text |:initial-loop) (:id |9KqL_QDj9hleaf)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128942718) (:text |the-loop) (:id |U5iwr1HTWZ)
+                                        :id |9KqL_QDj9h
+                                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128943422)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128947362) (:text |:hit-times) (:id |FPV8LzyEUjleaf)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134175317) (:text |0) (:id |VSKQzCVxtJ)
+                                        :id |FPV8LzyEUj
+                                      |t $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128948879)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128951507) (:text |:last-hit) (:id |NpAL1OHgPYleaf)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128955039) (:text |the-loop) (:id |lugYRO9iLl)
+                                        :id |NpAL1OHgPY
+                                    :id |yvBSeouNLC
+                                :id |2n7PBYA7e
+                            :id |MlTpbQoGHI
+                        :id |OUBT2L_su
+                      |n $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130232741) (:text |update) (:id |lrni0sMWA1)
+                    :id |1HNReBlkDS
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128830213) (:text |let) (:id |9wUtMKT7D6)
+                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128830500)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128830636)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128835557) (:text |the-loop) (:id |ESGK0visnS)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128836499)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128841167) (:text |@*cache-states) (:id |WsKhif1Auj)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128843955) (:text |:loop) (:id |PiPL_IiTkh)
+                            :id |s47mGTsQqR
+                        :id |juZVNmKUDA
+                    :id |HRsqS06klD
+                :id |_95C8et-Bs
+            :id |vnggWDhOjS
+          |access-cache $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128309140)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128309140) (:text |defn) (:id |teFhw53fil)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128309140) (:text |access-cache) (:id |YX5Z79EzDD)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128309140)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128314928) (:text |params) (:id |kguzgJfzP)
+                :id |KkB7T3LTLh
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128316087)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128322842) (:text |let) (:id |w8WD6E_vWleaf)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128323054)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128323211)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128324595) (:text |caches) (:id |2hvC-zkBI9)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128326852)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128343069) (:text |@*cache-states) (:id |BISVI1Sh-M)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128352898) (:text |:caches) (:id |ZIKgQmOwP)
+                            :id |ZDmxIv1pj
+                        :id |DEqkdLKGz
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128647844)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128661146) (:text |the-loop) (:id |GyenQ5H4W-leaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128651299)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128655798) (:text |@*cache-states) (:id |LTF5JRsS7Q)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128657833) (:text |:loop) (:id |x2hg3HO9K)
+                            :id |9az83cVJI
+                        :id |GyenQ5H4W-
+                    :id |XnlkJGLrPG
+                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128355000)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128356334) (:text |if) (:id |3Q86gWR1xpleaf)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128356808)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128358053) (:text |contains?) (:id |csJfqbqj1N)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128361201) (:text |caches) (:id |V1P5a0KEh)
+                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128420339) (:text |params) (:id |qYZ7gVMmE)
+                        :id |0VIqw0m89B
+                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128481652)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130368116)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128441069)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128442542) (:text |get) (:id |dorUj5wJuleaf)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128443828) (:text |caches) (:id |5iFlOBiQHn)
+                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128445236) (:text |params) (:id |dkMwBIKHWt)
+                                :id |dorUj5wJu
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130369399) (:text |:value) (:id |UGK8-1gvDS)
+                            :id |Y-CAyVoUU
+                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128484706) (:text |do) (:id |BahhW16e3C)
+                          |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128485596)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128491562) (:text |swap!) (:id |AtIFHGZ2M)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128495222) (:text |*cache-states) (:id |_pH_0S-DhB)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128498831) (:text |update-in) (:id |xm8gying6H)
+                              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128499644)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128499875) (:text |[]) (:id |f7nRS2xhvi)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128500874) (:text |:caches) (:id |5D5IfoA2tS)
+                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128501974) (:text |params) (:id |kNMCyG50bD)
+                                :id |8PXBtzO96
+                              |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128502750)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128503053) (:text |fn) (:id |Gy60SB1wR2)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128503350)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128508191) (:text |info) (:id |WR2XBFNtQ)
+                                    :id |aeUWfrTLU7
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128640843)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128643449) (:text |->) (:id |R2gZe7l5Hleaf)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128664990) (:text |info) (:id |e8BBCaExtS)
+                                      |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128665298)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128666102) (:text |assoc) (:id |Xixcy-o6W)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128676921) (:text |:last-hit) (:id |Jc49kqquCc)
+                                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128680281) (:text |the-loop) (:id |mv9UM8A1F)
+                                        :id |lvxAh2-O_I
+                                      |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128697028)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128698589) (:text |update) (:id |HikhGlDcDAleaf)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130384122) (:text |:hit-times) (:id |JTG2wQ0I8)
+                                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128704706) (:text |inc) (:id |AbnH_GTuz)
+                                        :id |HikhGlDcDA
+                                    :id |R2gZe7l5H
+                                :id |7co2IQCwvO
+                            :id |M0qZyKqRSd
+                        :id |dXck_cvSIT
+                      |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128447019) (:text |nil) (:id |jtVyceiHr)
+                    :id |3Q86gWR1xp
+                :id |w8WD6E_vW
+            :id |uQ2Uff3p-_
+          |reset-caches! $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132403110)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132403110) (:text |defn) (:id |h1QvEGJctn)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132403110) (:text |reset-caches!) (:id |Qz29aNCVZ0)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132403110) (:data $ {}) (:id |vMyj7DWoiC)
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132407725)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132426305) (:text |*cache-states) (:id |H32_TzNLy6)
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132439328) (:text |swap!) (:id |lSOXvXh5-)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132474658) (:text |assoc) (:id |STRumTPqZZ)
+                  |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132474658) (:text |:loop) (:id |OT-hXDJkYQ)
+                  |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132474658) (:text |0) (:id |qtLGL9hQZ9)
+                  |y $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132480471) (:text |:caches) (:id |g1T4KP2HU)
+                  |yT $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132480782)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132481522) (:text |{}) (:id |cm_vuc1Eot)
+                    :id |Cd5KK52S_b
+                :id |Dp6_xcPH5
+            :id |KArs6GX0uF
+        :proc $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592127749755) (:data $ {}) (:id |BAxJ3-RYHF)
+        :configs $ {}
       |respo.test.html $ {}
         :ns $ {} (:type :expr) (:id |SyeC1bD_gz) (:by |rJoDgvdeG) (:at 1511710949521)
           :data $ {}
@@ -8386,6 +8939,496 @@
                       |T $ {} (:type :leaf) (:id |B19k8fgutRFW) (:text |:padding) (:by |root) (:at 1504774121421)
                       |j $ {} (:type :leaf) (:id |B1ikIMgdKCYZ) (:text "||4px 0px") (:by |root) (:at 1504774121421)
         :proc $ {} (:type :expr) (:id |BylJIGl_KAK-) (:by nil) (:at 1504774121421) (:data $ {})
+      |respo.app.comp.caches $ {}
+        :ns $ {} (:type :expr) (:id |Bk7tGefluYCtb) (:by nil) (:at 1504774121421)
+          :data $ {}
+            |T $ {} (:type :leaf) (:id |Hk4FfxflOtCtZ) (:text |ns) (:by |root) (:at 1504774121421)
+            |j $ {} (:type :leaf) (:id |B1rKfgGeOYAKZ) (:text |respo.app.comp.caches) (:by |root) (:at 1504774121421)
+            |v $ {} (:type :expr) (:id |rJxCLmq8cZ) (:by |root) (:at 1505301334158)
+              :data $ {}
+                |T $ {} (:type :leaf) (:text |:require) (:id |rJxCLmq8cZleaf) (:by |root) (:at 1505301334988)
+                |j $ {} (:type :expr) (:id |SJephDnTaW) (:by nil) (:at 1504774121421)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:id |B1FYfgGldtAFZ) (:text |[]) (:by |root) (:at 1504774121421)
+                    |j $ {} (:type :leaf) (:id |SkcKzlGe_tCKW) (:text |respo.core) (:by |root) (:at 1540830062992)
+                    |r $ {} (:type :leaf) (:id |B1oYGxGxdYAKW) (:text |:refer) (:by |root) (:at 1508915128682)
+                    |v $ {} (:type :expr) (:id |r1hFGxfxdYAY-) (:by nil) (:at 1504774121421)
+                      :data $ {}
+                        |T $ {} (:type :leaf) (:id |Sy6YGxMeOt0Y-) (:text |[]) (:by |root) (:at 1504774121421)
+                        |j $ {} (:type :leaf) (:id |BJAFMezldYRYZ) (:text |defcomp) (:by |root) (:at 1504774121421)
+                        |r $ {} (:type :leaf) (:id |SJy5GgGguKAF-) (:text |div) (:by |root) (:at 1504774121421)
+                        |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130040812) (:text |button) (:id |WumvxQMz-q)
+                        |n $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132814598) (:text |defplugin) (:id |Gsv32t3tN7)
+                        |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132964418) (:text |span) (:id |IlsAjwoUa8)
+                        |y $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132966942) (:text |>>) (:id |ID766mcOH)
+                |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130012394)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130012394) (:text |[]) (:id |U5iJpHqg0c)
+                    |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130015339) (:text |respo.app.style.widget) (:id |ir9rIWXs7F)
+                    |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130016572) (:text |:as) (:id |eDUacQiY79)
+                    |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130017557) (:text |widget) (:id |tr1mAm8TL5)
+                  :id |1vNGPZPyEr
+                |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130045212)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130045493) (:text |[]) (:id |VKKxlrq_Yleaf)
+                    |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130048203) (:text |respo.comp.space) (:id |sigq1m3PdY)
+                    |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130048865) (:text |:refer) (:id |TGBPPE0QP4)
+                    |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130049053)
+                      :data $ {}
+                        |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130049205) (:text |[]) (:id |mIecKrul_L)
+                        |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130050362) (:text |=<) (:id |vLHHAyFmyo)
+                      :id |ttENSQQIfw
+                  :id |VKKxlrq_Y
+                |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130067503)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130067826) (:text |[]) (:id |Sc0OyKmtwleaf)
+                    |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130069822) (:text |respo.caches) (:id |7mNZa4b2QH)
+                    |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130071668) (:text |:as) (:id |asnW9dKafB)
+                    |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130074386) (:text |caches) (:id |sz3R4MFnwk)
+                  :id |Sc0OyKmtw
+        :defs $ {}
+          |comp-caches $ {} (:type :expr) (:id |Hyq9zefl_KCKW) (:by nil) (:at 1504774121421)
+            :data $ {}
+              |T $ {} (:type :leaf) (:id |rJoqzeGx_YAYW) (:text |defcomp) (:by |root) (:at 1504774121421)
+              |j $ {} (:type :leaf) (:id |HJh5zgMxdKAtW) (:text |comp-caches) (:by |root) (:at 1504774121421)
+              |r $ {} (:type :expr) (:id |r169fgfg_tCtZ) (:by nil) (:at 1504774121421)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132796866) (:text |states) (:id |1WyeV7TR_p)
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132773661)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132927217)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:id |r1R5zgMeuYAF-) (:by nil) (:at 1504774121421)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:id |H1kjzxGl_KRK-) (:text |div) (:by |root) (:at 1504774121421)
+                          |w $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129953413)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130057114) (:text |div) (:id |-8qyDPDxKCleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130329007)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129958044) (:text |{}) (:id |VP9opdEW1M)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129958673)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129961225) (:text |:inner-text) (:id |lliQB_rPc)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130331800) (:text "|\"Access") (:id |HBa8gTMjly)
+                                    :id |DkYhcqAypW
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129965950)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129969390) (:text |:on-click) (:id |9KeKmsbPrOleaf)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129969936)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970218) (:text |fn) (:id |6czpae9tWh)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129970597)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970816) (:text |e) (:id |8HBfq8um9u)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129971875) (:text |d!) (:id |Firk99qoEM)
+                                            :id |o8CPh3phdc
+                                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130356507)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130098557)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130335713) (:text |caches/access-cache) (:id |eY_thzNcfleaf)
+                                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130195621)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130193321) (:text |[]) (:id |PZHWVsrAH)
+                                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130193722) (:text |1) (:id |kkAKjWfZKI)
+                                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130193969) (:text |2) (:id |X-ycS56iJd)
+                                                      |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130418088) (:text |3) (:id |wo7H6rwax)
+                                                    :id |s_ldHRLs43
+                                                :id |eY_thzNcf
+                                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130357673) (:text |println) (:id |u8sRhYwTfC)
+                                            :id |nk2Gs2AOUW
+                                        :id |0sqWa_e0NU
+                                    :id |9KeKmsbPrO
+                                  |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130020211)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130021830) (:text |:style) (:id |9U68NmCcvleaf)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130024846) (:text |widget/button) (:id |C9Egj4sHQy)
+                                    :id |9U68NmCcv
+                                :id |UGGELzzQnT
+                                :text "|\"Acc"
+                            :id |T1JfCWeNm
+                          |s $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130269125)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130269627) (:text |=<) (:id |omeGAvmz4leaf)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130270378) (:text |8) (:id |tc4_zPsT4z)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130270896) (:text |nil) (:id |aXrNzm3DmK)
+                            :id |omeGAvmz4
+                          |j $ {} (:type :expr) (:id |B1xszlfeOYCYW) (:by nil) (:at 1504774121421)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:id |H1bszefg_KCtZ) (:text |{}) (:by |root) (:at 1504774121421)
+                          |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129953413)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130057114) (:text |div) (:id |-8qyDPDxKCleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130329007)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129958044) (:text |{}) (:id |VP9opdEW1M)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129958673)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129961225) (:text |:inner-text) (:id |lliQB_rPc)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132509570) (:text "|\"Reset") (:id |HBa8gTMjly)
+                                    :id |DkYhcqAypW
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129965950)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129969390) (:text |:on-click) (:id |9KeKmsbPrOleaf)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129969936)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970218) (:text |fn) (:id |6czpae9tWh)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129970597)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970816) (:text |e) (:id |8HBfq8um9u)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129971875) (:text |d!) (:id |Firk99qoEM)
+                                            :id |o8CPh3phdc
+                                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132517709)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132517709) (:text |caches/reset-caches!) (:id |05J65b9_KH)
+                                            :id |bMLJ38hM5r
+                                        :id |0sqWa_e0NU
+                                    :id |9KeKmsbPrO
+                                  |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130020211)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130021830) (:text |:style) (:id |9U68NmCcvleaf)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130024846) (:text |widget/button) (:id |C9Egj4sHQy)
+                                    :id |9U68NmCcv
+                                :id |UGGELzzQnT
+                                :text "|\"Acc"
+                            :id |phhl8A26o
+                          |t $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129953413)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130057114) (:text |div) (:id |-8qyDPDxKCleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129957647)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129958044) (:text |{}) (:id |VP9opdEW1M)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129958673)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129961225) (:text |:inner-text) (:id |lliQB_rPc)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129965068) (:text "|\"Add cache") (:id |HBa8gTMjly)
+                                    :id |DkYhcqAypW
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129965950)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129969390) (:text |:on-click) (:id |9KeKmsbPrOleaf)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129969936)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970218) (:text |fn) (:id |6czpae9tWh)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129970597)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970816) (:text |e) (:id |8HBfq8um9u)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129971875) (:text |d!) (:id |Firk99qoEM)
+                                            :id |o8CPh3phdc
+                                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130098557)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130213706) (:text |caches/write-cache!) (:id |eY_thzNcfleaf)
+                                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130195621)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130193321) (:text |[]) (:id |PZHWVsrAH)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130193722) (:text |1) (:id |kkAKjWfZKI)
+                                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130193969) (:text |2) (:id |X-ycS56iJd)
+                                                  |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130406723) (:text |3) (:id |wo7H6rwax)
+                                                :id |s_ldHRLs43
+                                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130407916) (:text |6) (:id |BggYa0IPKm)
+                                            :id |eY_thzNcf
+                                        :id |0sqWa_e0NU
+                                    :id |9KeKmsbPrO
+                                  |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130020211)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130021830) (:text |:style) (:id |9U68NmCcvleaf)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130024846) (:text |widget/button) (:id |C9Egj4sHQy)
+                                    :id |9U68NmCcv
+                                :id |UGGELzzQnT
+                            :id |fCZ4WzITC8
+                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129953413)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130057114) (:text |div) (:id |-8qyDPDxKCleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129957647)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129958044) (:text |{}) (:id |VP9opdEW1M)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129958673)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129961225) (:text |:inner-text) (:id |lliQB_rPc)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130278053) (:text "|\"Loop") (:id |HBa8gTMjly)
+                                    :id |DkYhcqAypW
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129965950)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129969390) (:text |:on-click) (:id |9KeKmsbPrOleaf)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129969936)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970218) (:text |fn) (:id |6czpae9tWh)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129970597)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970816) (:text |e) (:id |8HBfq8um9u)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129971875) (:text |d!) (:id |Firk99qoEM)
+                                            :id |o8CPh3phdc
+                                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130098557)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130284738) (:text |caches/new-loop!) (:id |eY_thzNcfleaf)
+                                            :id |eY_thzNcf
+                                          |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130290852)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130290852) (:text |println) (:id |tRsysG0gbW)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130290852) (:text |@caches/*cache-states) (:id |2Nv_y4djL6)
+                                            :id |FrF6B3g1C8
+                                        :id |0sqWa_e0NU
+                                    :id |9KeKmsbPrO
+                                  |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130020211)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130021830) (:text |:style) (:id |9U68NmCcvleaf)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130024846) (:text |widget/button) (:id |C9Egj4sHQy)
+                                    :id |9U68NmCcv
+                                :id |UGGELzzQnT
+                            :id |-8qyDPDxKC
+                          |y $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129953413)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130057114) (:text |div) (:id |-8qyDPDxKCleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130329007)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129958044) (:text |{}) (:id |VP9opdEW1M)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129958673)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129961225) (:text |:inner-text) (:id |lliQB_rPc)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134799800) (:text "|\"GC") (:id |HBa8gTMjly)
+                                    :id |DkYhcqAypW
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129965950)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129969390) (:text |:on-click) (:id |9KeKmsbPrOleaf)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129969936)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970218) (:text |fn) (:id |6czpae9tWh)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592129970597)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129970816) (:text |e) (:id |8HBfq8um9u)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592129971875) (:text |d!) (:id |Firk99qoEM)
+                                            :id |o8CPh3phdc
+                                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132517709)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134810515) (:text |caches/perform-gc!) (:id |05J65b9_KH)
+                                            :id |bMLJ38hM5r
+                                        :id |0sqWa_e0NU
+                                    :id |9KeKmsbPrO
+                                  |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130020211)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130021830) (:text |:style) (:id |9U68NmCcvleaf)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130024846) (:text |widget/button) (:id |C9Egj4sHQy)
+                                    :id |9U68NmCcv
+                                :id |UGGELzzQnT
+                                :text "|\"Acc"
+                            :id |pNRYHpZmZ
+                          |u $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592130326827)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130326827) (:text |=<) (:id |xX0zfCAXNg)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130326827) (:text |8) (:id |rfKY95J9sw)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592130326827) (:text |nil) (:id |3td8LqP_t8)
+                            :id |A8UAvFmAhc
+                          |wT $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132506693)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132506693) (:text |=<) (:id |D_dEbbqsF2)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132506693) (:text |8) (:id |fCR7KslD2D)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132506693) (:text |nil) (:id |FEKJSCvB0k)
+                            :id |LKLccDIgqZ
+                          |xT $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134797685)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134797685) (:text |=<) (:id |ioo5Wp_mLU)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134797685) (:text |8) (:id |FjriAfgvn4)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134797685) (:text |nil) (:id |hgAyhOqefO)
+                            :id |B4CAAUvJgq
+                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132927906) (:text |div) (:id |SpA93nx_yA)
+                      |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132928099)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132928432) (:text |{}) (:id |okWBjC1lYt)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134780149)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134781073) (:text |:style) (:id |bxnV3Sjqry)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134781909)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134782441) (:text |{}) (:id |VZnMulnkSy)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592134782709)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134783666) (:text |:padding) (:id |HoI6jtVOZ2)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592134785784) (:text |8) (:id |ewD-YqXQOd)
+                                    :id |fmRyPApCSy
+                                :id |rAiRKTrOO8
+                            :id |qxrgcQd2O
+                        :id |amTi-kTMw
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132929940)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132930610) (:text |:ui) (:id |Jr1wWYOEbKleaf)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132935690) (:text |value-plugin) (:id |WuTiCMzv_)
+                        :id |Jr1wWYOEbK
+                      |b $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132939887)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132940522) (:text |div) (:id |BewBd9WzcSleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132940738)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132941046) (:text |{}) (:id |bCNOwESouD)
+                            :id |5xq1aWTv2K
+                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132944692)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |div) (:id |6_vmOtgW54)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132944692)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |{}) (:id |p_h7mCyGz8)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132944692)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |:inner-text) (:id |YE19XFNqAR)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133191374) (:text "|\"Trigger") (:id |Ag51Czt-2S)
+                                    :id |ymAqdT1PCE
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132944692)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |:style) (:id |gf-Yaw0kk2)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |widget/button) (:id |QL40i_hTDQ)
+                                    :id |_zHiodfvBU
+                                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132944692)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |:on-click) (:id |KHC5zOIlAe)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132944692)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |fn) (:id |6BR_6AeKMt6)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132944692)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |e) (:id |Qpj70nACTtX)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132944692) (:text |d!) (:id |NtftZGpAk-U)
+                                            :id |Mc4819n-Hbm
+                                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132944692)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132949168)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132950444) (:text |:toggle) (:id |CrDdHDdGg2_)
+                                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132954712) (:text |value-plugin) (:id |63o8VdqTPb)
+                                                :id |pXG_xGgHP
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133001185) (:text |d!) (:id |OOopMIgTWN)
+                                            :id |rddbaSYLWpt
+                                        :id |w4M5bVfKk6
+                                    :id |mjUDpwWfeU
+                                :id |IqqLPFoHZn
+                            :id |P1DKmljXpT
+                        :id |BewBd9WzcS
+                      |X $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592133193078)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133194702) (:text |=<) (:id |zYcDjAxwfleaf)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133195924) (:text |nil) (:id |C7commCO6s)
+                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133196309) (:text |8) (:id |HTQ4fHWSJ)
+                        :id |zYcDjAxwf
+                    :id |dpq-nmChQ
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132774911) (:text |let) (:id |gaYehRlZNL)
+                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132775165)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592133104408)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133121108) (:text |value-plugin) (:id |5vm8US0S8-)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592133121899)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132797870)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132798385) (:text |>>) (:id |BAgOEROTiC)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132799166) (:text |states) (:id |qTdHiD5Axt)
+                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132801111) (:text |:count) (:id |jcDJLwuM-q)
+                                :id |jK2MDs5pU7
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133123437) (:text |use-demo) (:id |jK6_X3gbA)
+                            :id |t7hZ-R1-fn
+                        :id |Eg9n6lVHX-
+                    :id |OZYjz904x
+                :id |cHA8UgmOf
+          |use-demo $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132806215)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133453483) (:text |defplugin) (:id |PGdU7JnEbN)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132806215) (:text |use-demo) (:id |VrgYWVfxLv)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132806215)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132820183) (:text |states) (:id |DuY-CMNRO)
+                :id |_wCmx0cs13
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132825151)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132827903) (:text |let) (:id |LvyQIXEvXleaf)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132828128)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132828272)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132828934) (:text |state) (:id |thOwMzWjgF)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132829132)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132829709) (:text |or) (:id |yDM_t7VHTV)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132829936)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132830941) (:text |:data) (:id |qxa4cog38r)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132831717) (:text |states) (:id |TwdpW_UC1B)
+                                :id |gREoMcGS7W
+                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132832307)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132832925) (:text |{}) (:id |0EM_k7L9x)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132833650)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132883901) (:text |:status) (:id |Z9BUUwbv9)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132889026) (:text |true) (:id |5OYlQkdk4l)
+                                    :id |zkEEw8LKfb
+                                :id |eGkLDGMYfj
+                            :id |ibzWm6hPp
+                        :id |9dDyrkClWR
+                      |D $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132907628)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132908399) (:text |cursor) (:id |YkfE8xkqbtleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132908594)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132909466) (:text |:cursor) (:id |MUCyH1eY7Z)
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132912498) (:text |states) (:id |8mDnPo4AcS)
+                            :id |RkNyhWYM3h
+                        :id |YkfE8xkqbt
+                    :id |WJrBoCAvb
+                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132895873)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132897447)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132837131)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132837882) (:text |span) (:id |dIRLyURDpleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132838142)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132838496) (:text |{}) (:id |6Ui6tzn2HB)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132838687)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132840331) (:text |:inner-text) (:id |AjzPw9COaj)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132841133)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132851674) (:text |str) (:id |NeoeH2LWC3)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132842794)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132845344) (:text |state) (:id |dlVR5NYmo-)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132887699) (:text |:status) (:id |lu7p93J1BJ)
+                                            :id |Zr5s6yj4UE
+                                          |b $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592133168202) (:text "|\"status: ") (:id |9CKgcdDsPG)
+                                        :id |FAEdBJrpw
+                                    :id |NqXTQMzW7V
+                                :id |HieqYuVBX
+                            :id |dIRLyURDp
+                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132898657) (:text |:ui) (:id |_6GBcgQjNL)
+                        :id |Z62t89whvk
+                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132896327) (:text |{}) (:id |tVzc2Chyu)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132899122)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132901218) (:text |:toggle) (:id |AKKljEgprleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132901477)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132902178) (:text |fn) (:id |6v4Jv2c8e9)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132902387)
+                                :data $ {}
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132904578) (:text |d!) (:id |VuVW3a2dM9)
+                                :id |xsBIECfkwf
+                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132904912)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132905461) (:text |d!) (:id |AvYMaZdStLleaf)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132906561) (:text |cursor) (:id |UYVkX4GN0z)
+                                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132915470)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132916208) (:text |update) (:id |AZ223fq7H)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132917359) (:text |state) (:id |vnfj0g-n2k)
+                                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132918695) (:text |:status) (:id |vX3YPPmNTQ)
+                                      |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132919897) (:text |not) (:id |Ol5XAwC9J1)
+                                    :id |vvPsDg_U8A
+                                :id |AvYMaZdStL
+                            :id |9l8Hwz50Wt
+                        :id |AKKljEgpr
+                    :id |nAzmPUPFT
+                :id |LvyQIXEvX
+            :id |H9gmTzUVP0
+        :proc $ {} (:type :expr) (:id |B1tcMlfgutRY-) (:by nil) (:at 1504774121421) (:data $ {})
       |respo.test.main $ {}
         :ns $ {} (:type :expr) (:id |SyxIkWDdxz) (:by |rJoDgvdeG) (:at 1511710942011)
           :data $ {}
@@ -8694,6 +9737,35 @@
                       |j $ {} (:type :expr) (:id |ByM-sU3wc-) (:by |root) (:at 1505375897493)
                         :data $ {}
                           |T $ {} (:type :leaf) (:id |ry-MSlMg_FRt-) (:text |{}) (:by |root) (:at 1505375899450)
+          |cache-info $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128521861)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128524075) (:text |def) (:id |ia3gVwVIL2)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128521861) (:text |cache-info) (:id |MX2BFDXi88)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128521861)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128525060) (:text |{}) (:id |nXiz-jACSC)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128525355)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128526375) (:text |:value) (:id |rKk_ngiuW)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128527024) (:text |nil) (:id |Mb4YnZ50vz)
+                    :id |n_PUMo8Ke9
+                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128527554)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128599812) (:text |:initial-loop) (:id |PpgGYspikRleaf)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128552155) (:text |nil) (:id |cNadDCqXA)
+                    :id |PpgGYspikR
+                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128548625)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128692796) (:text |:last-hit) (:id |5qr9MzX2vUleaf)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128577658) (:text |nil) (:id |tt6CwRGyQ)
+                    :id |5qr9MzX2vU
+                  |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592128604110)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128615161) (:text |:hit-times) (:id |SGfshmYgoleaf)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592128619977) (:text |0) (:id |uzgU0UX0D)
+                    :id |SGfshmYgo
+                :id |dQ9HOHQEI2
+            :id |ItQbBAdCtm
         :proc $ {} (:type :expr) (:id |BkQCNyWvqW) (:by |root) (:at 1505328949889) (:data $ {})
       |respo.comp.inspect $ {}
         :ns $ {} (:type :expr) (:id |Sk3mbgdKAYW) (:by nil) (:at 1504774121421)
@@ -10068,6 +11140,13 @@
                       :data $ {}
                         |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571584636147) (:text |[]) (:id |Hzj2kpOQ4z)
                         |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571584639313) (:text |collect-mounting) (:id |-kxkOeAosx)
+                |yy $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132244745)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132245055) (:text |[]) (:id |9tT0OaOnn1leaf)
+                    |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132247391) (:text |respo.caches) (:id |IfqHrrLKF)
+                    |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132248729) (:text |:as) (:id |AJm9cW5TQ4)
+                    |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132250658) (:text |caches) (:id |uvllX5XG-z)
+                  :id |9tT0OaOnn1
                 |yv $ {} (:type :expr) (:id |H1gD0pMcAZ) (:by |root) (:at 1509727695077)
                   :data $ {}
                     |T $ {} (:type :leaf) (:text |[]) (:id |H1gD0pMcAZleaf) (:by |root) (:at 1509727696555)
@@ -10819,6 +11898,10 @@
                               |j $ {} (:type :leaf) (:id |ryyGIlzlOKRKZ) (:text |@*global-element) (:by |root) (:at 1504774121421)
                               |r $ {} (:type :leaf) (:id |SJlz8lMluYRFZ) (:text |element) (:by |root) (:at 1504774121421)
                               |v $ {} (:type :leaf) (:id |SkZM8xMx_FAKb) (:text |@*changes) (:by |root) (:at 1504774121421)
+              |t $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592135595342)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592135595342) (:text |caches/new-loop!) (:id |HdLjUxhvYj)
+                :id |ycLYvMn1QZ
           |element-type $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1565455760753) (:id |OVlwxLHrfX)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1565455770526) (:text |def) (:id |_xLNxiOcH6)
@@ -10840,6 +11923,96 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:id |r1QX8lGedtCtZ) (:text |atom) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |Sk4XLeflOt0F-) (:text |nil) (:by |root) (:at 1504774121421)
+          |call-plugin-func $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132224051)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132224051) (:text |defn) (:id |e7S5ah_urz)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132224051) (:text |call-plugin-func) (:id |AwNTGTtiAz)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132224051)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132230087) (:text |f) (:id |Nme6YMXvdZ)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132232521) (:text |params) (:id |9bJFbmGnbW)
+                :id |y_lJJltiSM
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132700071)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132242173)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132254704)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132254877)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132233243)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132237055) (:text |concat) (:id |rqz25Mc2rleaf)
+                                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132237381)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132237622) (:text |[]) (:id |mZo7DciXX)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132238059) (:text |f) (:id |Arq_6RBgZu)
+                                    :id |2aJ3FRUG-P
+                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132240355) (:text |params) (:id |4EvWezjOiO)
+                                :id |rqz25Mc2r
+                              |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132256516) (:text |xs) (:id |bXOH0ZyVB)
+                            :id |sAzsv12MeV
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132261119)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132264404) (:text |v) (:id |FKnzFIKojleaf)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132265515)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132270206) (:text |caches/access-cache) (:id |tHqgAYp-jD)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132270939) (:text |xs) (:id |59BlW7S7K1)
+                                :id |nj7HbWfBs
+                            :id |FKnzFIKoj
+                        :id |UatAPNt4XW
+                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132254033) (:text |let) (:id |DQ3HHXZ2zd)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132279567)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132281032) (:text |if) (:id |aaKLsyRW5vleaf)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132281246)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132281940) (:text |some?) (:id |bW3ZqzRpZ)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132282343) (:text |v) (:id |UC6C6kOe8)
+                            :id |Yp8MbJF1E0
+                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132284331) (:text |v) (:id |BQTVy_ozY)
+                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132285003)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132288301) (:text |let) (:id |-q7MLuLvRx)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132288560)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132288714)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132289755) (:text |result) (:id |fQijh3oPf0)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132290165)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132293542) (:text |apply) (:id |jUNycl41ks)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132293817) (:text |f) (:id |kio4p21Wy9)
+                                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132296882) (:text |params) (:id |llZLTmshSq)
+                                        :id |1zjvP6JfM
+                                    :id |c-ZpLTWRfH
+                                :id |KmtfsxB1v3
+                              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132298473)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132303130) (:text |caches/write-cache!) (:id |dvk23rbcOleaf)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132305047) (:text |xs) (:id |fBn8SuwXIP)
+                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132306569) (:text |result) (:id |FM4YjzAbB)
+                                :id |dvk23rbcO
+                              |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132308265) (:text |result) (:id |XFdmIiKCO)
+                            :id |nZNiTOQ1oD
+                        :id |aaKLsyRW5v
+                    :id |zp30I3N6_
+                  |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132701512) (:text |if) (:id |WcrNxlSwIp)
+                  |L $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132702343)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132725900) (:text |some) (:id |7iEsRAYtpg)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132707725) (:text |fn?) (:id |3HgyRZgw2)
+                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132709283) (:text |params) (:id |w6YrwMwpG)
+                    :id |jVjdiUxB4
+                  |P $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132713390)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132714440) (:text |apply) (:id |p5RmGEEZF8)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132715738) (:text |f) (:id |vmgiY06xOz)
+                      |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132716756) (:text |params) (:id |6fxiia10Ja)
+                    :id |hSpaSk2q8
+                :id |l59YVHJmo
+            :id |w0SoFSuirR
           |clear-cache! $ {} (:type :expr) (:id |SJHXLgGguYCKW) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:id |Bk8mLgGxOYCKW) (:text |defn) (:by |root) (:at 1504774121421)
@@ -10850,6 +12023,10 @@
                   |T $ {} (:type :leaf) (:id |BkqmIxzl_tRtb) (:text |reset!) (:by |root) (:at 1504774121421)
                   |j $ {} (:type :leaf) (:id |S1iXLlfxOKRYb) (:text |*dom-element) (:by |root) (:at 1504774121421)
                   |r $ {} (:type :leaf) (:id |rJn7LxGxOtCFZ) (:text |nil) (:by |root) (:at 1504774121421)
+              |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1592132484436)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1592132490288) (:text |caches/reset-caches!) (:id |rCgcMpeX6leaf)
+                :id |rCgcMpeX6
           |confirm-child $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1571849837293) (:id |bhrxPnE2lQ)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1571849837293) (:text |defn) (:id |zw5Ts4F7OO)

--- a/macros/respo/core.clj
+++ b/macros/respo/core.clj
@@ -60,6 +60,9 @@
                   body))})))
 
 (defmacro defplugin [x params & body]
+  (assert (symbol? x) "1st argument should be a symbol")
+  (assert (coll? params) "2nd argument should be a collection")
+  (assert (some? (last body)) "defplugin should return something")
   (let [plugin-name (gensym "plugin-")]
     `(do
        (defn ~plugin-name [~@params] ~@body)

--- a/macros/respo/core.clj
+++ b/macros/respo/core.clj
@@ -58,3 +58,9 @@
                 ~@(if (empty? body)
                   `((js/console.warn (str "WARNING: " '~effect-name " has no code for handling effects!")))
                   body))})))
+
+(defmacro defplugin [x params & body]
+  (let [plugin-name (gensym "plugin-")]
+    `(do
+       (defn ~plugin-name [~@params] ~@body)
+       (defn ~x [~@params] (respo.core/call-plugin-func ~plugin-name [~@params])))))

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Respo/respo#readme",
   "dependencies": {},
   "devDependencies": {
-    "shadow-cljs": "^2.9.10",
+    "shadow-cljs": "^2.10.7",
     "source-map-support": "^0.5.19",
     "ws": "^7.3.0"
   }

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.12.1"
+{:version "0.12.2-a1"
  :group-id "respo"
  :artifact-id "respo"
  :skip-tag true

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.12.2-a1"
+{:version "0.12.2-a2"
  :group-id "respo"
  :artifact-id "respo"
  :skip-tag true

--- a/scripts/plugin.clj
+++ b/scripts/plugin.clj
@@ -1,0 +1,8 @@
+
+(defmacro defplugin [x params & body]
+  (let [plugin-name (gensym "plugin-")]
+    `(do
+       (defn ~plugin-name [~@params] ~@body)
+       (defn ~x [~@params] (respo.core/call-plugin-func ~plugin-name ~params)))))
+
+(println (macroexpand-1 '(defplugin g [a b] (+ a b))))

--- a/src/respo/app/comp/caches.cljs
+++ b/src/respo/app/comp/caches.cljs
@@ -1,0 +1,52 @@
+
+(ns respo.app.comp.caches
+  (:require [respo.core :refer [defcomp defplugin div button span >>]]
+            [respo.comp.space :refer [=<]]
+            [respo.app.style.widget :as widget]
+            [respo.caches :as caches]))
+
+(defplugin
+ use-demo
+ (states)
+ (let [cursor (states :cursor), state (or (:data states) {:status true})]
+   {:ui (span {:inner-text (str "status: " (state :status))}),
+    :toggle (fn [d!] (d! cursor (update state :status not)))}))
+
+(defcomp
+ comp-caches
+ (states)
+ (let [value-plugin (use-demo (>> states :count))]
+   (div
+    {:style {:padding 8}}
+    (div
+     {}
+     (div
+      {:inner-text "Loop",
+       :style widget/button,
+       :on-click (fn [e d!] (caches/new-loop!) (println @caches/*cache-states))})
+     (=< 8 nil)
+     (div
+      {:inner-text "Add cache",
+       :style widget/button,
+       :on-click (fn [e d!] (caches/write-cache! [1 2 3] 6))})
+     (=< 8 nil)
+     (div
+      {:inner-text "Access",
+       :style widget/button,
+       :on-click (fn [e d!] (println (caches/access-cache [1 2 3])))})
+     (=< 8 nil)
+     (div
+      {:inner-text "Reset",
+       :style widget/button,
+       :on-click (fn [e d!] (caches/reset-caches!))})
+     (=< 8 nil)
+     (div
+      {:inner-text "GC", :style widget/button, :on-click (fn [e d!] (caches/perform-gc!))}))
+    (=< nil 8)
+    (div
+     {}
+     (div
+      {:inner-text "Trigger",
+       :style widget/button,
+       :on-click (fn [e d!] ((:toggle value-plugin) d!))}))
+    (:ui value-plugin))))

--- a/src/respo/app/comp/container.cljs
+++ b/src/respo/app/comp/container.cljs
@@ -1,7 +1,9 @@
 
 (ns respo.app.comp.container
   (:require [respo.core :refer [defcomp div span <> >>]]
-            [respo.app.comp.todolist :refer [comp-todolist]]))
+            [respo.app.comp.todolist :refer [comp-todolist]]
+            [respo.app.comp.caches :refer [comp-caches]]
+            [respo.comp.space :refer [=<]]))
 
 (def style-global {:font-family "Avenir,Verdana"})
 
@@ -14,4 +16,6 @@
    (div
     {:style style-global}
     (comp-todolist states (:tasks store))
-    (div {:style style-states} (<> (str "states: " (pr-str (:states store))))))))
+    (div {:style style-states} (<> (str "states: " (pr-str (:states store)))))
+    (=< nil 40)
+    (comp-caches (>> states :caches)))))

--- a/src/respo/caches.cljs
+++ b/src/respo/caches.cljs
@@ -1,0 +1,65 @@
+
+(ns respo.caches )
+
+(defonce *cache-states
+  (atom {:loop 0, :caches {}, :gc {:cold-duration 400, :trigger-loop 100, :elapse-loop 50}}))
+
+(defn access-cache [params]
+  (let [caches (@*cache-states :caches), the-loop (@*cache-states :loop)]
+    (if (contains? caches params)
+      (do
+       (swap!
+        *cache-states
+        update-in
+        [:caches params]
+        (fn [info] (-> info (assoc :last-hit the-loop) (update :hit-times inc))))
+       (:value (get caches params)))
+      nil)))
+
+(defn perform-gc! []
+  (let [states-0 @*cache-states, gc (states-0 :gc)]
+    (swap!
+     *cache-states
+     update
+     :caches
+     (fn [caches]
+       (->> caches
+            (remove
+             (fn [[params info]]
+               (cond
+                 (zero? (info :hit-times)) true
+                 (> (- (states-0 :loop) (info :hit-loop)) (gc :elapse-loop)) true
+                 :else false)))
+            (into {}))))
+    (println
+     "[Respo Caches] Performed GC, from "
+     (count (states-0 :caches))
+     " to "
+     (count (@*cache-states :caches)))))
+
+(defn new-loop! []
+  (swap! *cache-states update :loop inc)
+  (let [loop-count (@*cache-states :loop), gc (@*cache-states :gc)]
+    (when (and (> loop-count (gc :cold-duration)) (zero? (rem loop-count (gc :trigger-loop))))
+      (perform-gc!))))
+
+(defn reset-caches! [] (swap! *cache-states assoc :loop 0 :caches {}))
+
+(defn write-cache! [params value]
+  (let [the-loop (@*cache-states :loop)]
+    (swap!
+     *cache-states
+     update
+     :caches
+     (fn [caches]
+       (if (contains? caches params)
+         (do
+          (println "[Respo Caches] already exisits" params)
+          (update
+           caches
+           params
+           (fn [info] (-> info (assoc :last-hit the-loop) (update :hit-times inc)))))
+         (assoc
+          caches
+          params
+          {:value value, :initial-loop the-loop, :last-hit the-loop, :hit-times 0}))))))

--- a/src/respo/schema.cljs
+++ b/src/respo/schema.cljs
@@ -1,6 +1,8 @@
 
 (ns respo.schema )
 
+(def cache-info {:value nil, :initial-loop nil, :last-hit nil, :hit-times 0})
+
 (def component
   {:name nil,
    :respo-node :component,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,8 +4,8 @@
 
 asn1.js@^4.0.0:
   version "4.10.1"
-  resolved "https://registry.npm.taobao.org/asn1.js/download/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
-  integrity sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=
+  resolved "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
+  integrity sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -13,41 +13,41 @@ asn1.js@^4.0.0:
 
 assert@^1.1.1:
   version "1.5.0"
-  resolved "https://registry.npm.taobao.org/assert/download/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
-  integrity sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=
+  resolved "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
+  integrity sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==
   dependencies:
     object-assign "^4.1.1"
     util "0.10.3"
 
 async-limiter@~1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/async-limiter/download/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=
+  resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 base64-js@^1.0.2:
   version "1.3.1"
-  resolved "https://registry.npm.taobao.org/base64-js/download/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=
+  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"
-  resolved "https://registry.npm.taobao.org/bn.js/download/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
-  integrity sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=
+  resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
+  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 bn.js@^5.1.1:
   version "5.1.2"
-  resolved "https://registry.npm.taobao.org/bn.js/download/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
-  integrity sha1-yWhpAtPJoncp9DqxD515wgBNp7A=
+  resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
+  integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
 
 brorand@^1.0.1:
   version "1.1.0"
-  resolved "https://registry.npm.taobao.org/brorand/download/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  resolved "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-aes/download/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
-  integrity sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=
+  resolved "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
   dependencies:
     buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
@@ -58,8 +58,8 @@ browserify-aes@^1.0.0, browserify-aes@^1.0.4:
 
 browserify-cipher@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/browserify-cipher/download/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
-  integrity sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=
+  resolved "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
+  integrity sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
   dependencies:
     browserify-aes "^1.0.4"
     browserify-des "^1.0.0"
@@ -67,8 +67,8 @@ browserify-cipher@^1.0.0:
 
 browserify-des@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/browserify-des/download/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
-  integrity sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=
+  resolved "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
+  integrity sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
   dependencies:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
@@ -77,7 +77,7 @@ browserify-des@^1.0.0:
 
 browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.npm.taobao.org/browserify-rsa/download/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
+  resolved "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
   integrity sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
   dependencies:
     bn.js "^4.1.0"
@@ -85,8 +85,8 @@ browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
 
 browserify-sign@^4.0.0:
   version "4.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-sign/download/browserify-sign-4.2.0.tgz#545d0b1b07e6b2c99211082bf1b12cce7a0b0e11"
-  integrity sha1-VF0LGwfmssmSEQgr8bEsznoLDhE=
+  resolved "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz#545d0b1b07e6b2c99211082bf1b12cce7a0b0e11"
+  integrity sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==
   dependencies:
     bn.js "^5.1.1"
     browserify-rsa "^4.0.1"
@@ -100,25 +100,25 @@ browserify-sign@^4.0.0:
 
 browserify-zlib@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.npm.taobao.org/browserify-zlib/download/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
-  integrity sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=
+  resolved "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
+  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   dependencies:
     pako "~1.0.5"
 
 buffer-from@^1.0.0:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-  integrity sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=
+  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer-xor@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.npm.taobao.org/buffer-xor/download/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+  resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@^4.3.0:
   version "4.9.2"
-  resolved "https://registry.npm.taobao.org/buffer/download/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
-  integrity sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=
+  resolved "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -126,44 +126,44 @@ buffer@^4.3.0:
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npm.taobao.org/builtin-status-codes/download/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+  resolved "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
-  resolved "https://registry.npm.taobao.org/cipher-base/download/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
-  integrity sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=
+  resolved "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
 console-browserify@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/console-browserify/download/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
-  integrity sha1-ZwY871fOts9Jk6KrOlWECujEkzY=
+  resolved "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
+  integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
 constants-browserify@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/constants-browserify/download/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+  resolved "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
 core-util-is@~1.0.0:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/core-util-is/download/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 create-ecdh@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.npm.taobao.org/create-ecdh/download/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
-  integrity sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=
+  resolved "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
+  integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/create-hash/download/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
-  integrity sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=
+  resolved "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
   dependencies:
     cipher-base "^1.0.1"
     inherits "^2.0.1"
@@ -173,8 +173,8 @@ create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
 
 create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
   version "1.1.7"
-  resolved "https://registry.npm.taobao.org/create-hmac/download/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
-  integrity sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=
+  resolved "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
   dependencies:
     cipher-base "^1.0.3"
     create-hash "^1.1.0"
@@ -185,8 +185,8 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
-  resolved "https://registry.npm.taobao.org/crypto-browserify/download/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
-  integrity sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=
+  resolved "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
   dependencies:
     browserify-cipher "^1.0.0"
     browserify-sign "^4.0.0"
@@ -202,16 +202,16 @@ crypto-browserify@^3.11.0:
 
 des.js@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/des.js/download/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
-  integrity sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=
+  resolved "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
+  integrity sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
-  resolved "https://registry.npm.taobao.org/diffie-hellman/download/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
-  integrity sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=
+  resolved "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
+  integrity sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
   dependencies:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
@@ -219,13 +219,13 @@ diffie-hellman@^5.0.0:
 
 domain-browser@^1.1.1:
   version "1.2.0"
-  resolved "https://registry.npm.taobao.org/domain-browser/download/domain-browser-1.2.0.tgz?cache=0&sync_timestamp=1590072213865&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomain-browser%2Fdownload%2Fdomain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
-  integrity sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=
+  resolved "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+  integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
 elliptic@^6.0.0, elliptic@^6.5.2:
   version "6.5.2"
-  resolved "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-  integrity sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=
+  resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -237,21 +237,21 @@ elliptic@^6.0.0, elliptic@^6.5.2:
 
 events@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.npm.taobao.org/events/download/events-3.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fevents%2Fdownload%2Fevents-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
-  integrity sha1-hCea8bNMt1qoi/X/KR9tC9mzGlk=
+  resolved "https://registry.npmjs.org/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
+  integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.npm.taobao.org/evp_bytestokey/download/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
-  integrity sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=
+  resolved "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
+  integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
 hash-base@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.npm.taobao.org/hash-base/download/hash-base-3.1.0.tgz?cache=0&sync_timestamp=1588318012719&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhash-base%2Fdownload%2Fhash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
-  integrity sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=
+  resolved "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
   dependencies:
     inherits "^2.0.4"
     readable-stream "^3.6.0"
@@ -259,15 +259,15 @@ hash-base@^3.0.0:
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
-  resolved "https://registry.npm.taobao.org/hash.js/download/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=
+  resolved "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/hmac-drbg/download/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  resolved "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
   dependencies:
     hash.js "^1.0.3"
@@ -276,43 +276,43 @@ hmac-drbg@^1.0.0:
 
 https-browserify@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/https-browserify/download/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+  resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
 ieee754@^1.1.4:
   version "1.1.13"
-  resolved "https://registry.npm.taobao.org/ieee754/download/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 inherits@2.0.1:
   version "2.0.1"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 inherits@2.0.3:
   version "2.0.3"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
-  resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 md5.js@^1.3.4:
   version "1.3.5"
-  resolved "https://registry.npm.taobao.org/md5.js/download/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
-  integrity sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=
+  resolved "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
@@ -320,26 +320,26 @@ md5.js@^1.3.4:
 
 miller-rabin@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.npm.taobao.org/miller-rabin/download/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
-  integrity sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=
+  resolved "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
   dependencies:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/minimalistic-assert/download/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=
+  resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 node-libs-browser@^2.0.0:
   version "2.2.1"
-  resolved "https://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
-  integrity sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=
+  resolved "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
+  integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
   dependencies:
     assert "^1.1.1"
     browserify-zlib "^0.2.0"
@@ -367,23 +367,23 @@ node-libs-browser@^2.0.0:
 
 object-assign@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fobject-assign%2Fdownload%2Fobject-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 os-browserify@^0.3.0:
   version "0.3.0"
-  resolved "https://registry.npm.taobao.org/os-browserify/download/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
+  resolved "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
 pako@~1.0.5:
   version "1.0.11"
-  resolved "https://registry.npm.taobao.org/pako/download/pako-1.0.11.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpako%2Fdownload%2Fpako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=
+  resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
   version "5.1.5"
-  resolved "https://registry.npm.taobao.org/parse-asn1/download/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
-  integrity sha1-ADJxND2ljclMrOSU+u89IUfs6g4=
+  resolved "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
+  integrity sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
@@ -394,13 +394,13 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
 
 path-browserify@0.0.1:
   version "0.0.1"
-  resolved "https://registry.npm.taobao.org/path-browserify/download/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
-  integrity sha1-5sTd1+06onxoogzE5Q4aTug7vEo=
+  resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
+  integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
 
 pbkdf2@^3.0.3:
-  version "3.0.17"
-  resolved "https://registry.npm.taobao.org/pbkdf2/download/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
-  integrity sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
+  integrity sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -410,18 +410,18 @@ pbkdf2@^3.0.3:
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
-  resolved "https://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha1-eCDZsWEgzFXKmud5JoCufbptf+I=
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 process@^0.11.10:
   version "0.11.10"
-  resolved "https://registry.npm.taobao.org/process/download/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 public-encrypt@^4.0.0:
   version "4.0.3"
-  resolved "https://registry.npm.taobao.org/public-encrypt/download/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
-  integrity sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=
+  resolved "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
+  integrity sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
   dependencies:
     bn.js "^4.1.0"
     browserify-rsa "^4.0.0"
@@ -432,43 +432,43 @@ public-encrypt@^4.0.0:
 
 punycode@1.3.2:
   version "1.3.2"
-  resolved "https://registry.npm.taobao.org/punycode/download/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@^1.2.4:
   version "1.4.1"
-  resolved "https://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 querystring-es3@^0.2.0:
   version "0.2.1"
-  resolved "https://registry.npm.taobao.org/querystring-es3/download/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+  resolved "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
 
 querystring@0.2.0:
   version "0.2.0"
-  resolved "https://registry.npm.taobao.org/querystring/download/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
-  resolved "https://registry.npm.taobao.org/randombytes/download/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=
+  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
 
 randomfill@^1.0.3:
   version "1.0.4"
-  resolved "https://registry.npm.taobao.org/randomfill/download/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
-  integrity sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=
+  resolved "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
+  integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
 readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.7"
-  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -480,8 +480,8 @@ readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
 
 readable-stream@^3.6.0:
   version "3.6.0"
-  resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha1-M3u9o63AcGvT4CRCaihtS0sskZg=
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -489,49 +489,49 @@ readable-stream@^3.6.0:
 
 readline-sync@^1.4.7:
   version "1.4.10"
-  resolved "https://registry.npm.taobao.org/readline-sync/download/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
-  integrity sha1-Qd9/u0tjEtZzARWUFFcFv1bYhzs=
+  resolved "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npm.taobao.org/ripemd160/download/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
-  integrity sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=
+  resolved "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
-  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.2.1.tgz?cache=0&sync_timestamp=1589129611964&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsafe-buffer%2Fdownload%2Fsafe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
-  resolved "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz?cache=0&sync_timestamp=1589129611964&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsafe-buffer%2Fdownload%2Fsafe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha1-mR7GnSluAxN0fVm9/St0XDX4go0=
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 setimmediate@^1.0.4:
   version "1.0.5"
-  resolved "https://registry.npm.taobao.org/setimmediate/download/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  resolved "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
-  resolved "https://registry.npm.taobao.org/sha.js/download/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=
+  resolved "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
 shadow-cljs-jar@1.3.2:
   version "1.3.2"
-  resolved "https://registry.npm.taobao.org/shadow-cljs-jar/download/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
-  integrity sha1-lyc6/hdHtqIxGRfByI2eJDyBlXs=
+  resolved "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
+  integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
 
-shadow-cljs@^2.9.10:
-  version "2.9.10"
-  resolved "https://registry.npm.taobao.org/shadow-cljs/download/shadow-cljs-2.9.10.tgz#d6b285b04f532593c85c47a9ba0cbbac7cdab906"
-  integrity sha1-1rKFsE9TJZPIXEepugy7rHzauQY=
+shadow-cljs@^2.10.7:
+  version "2.10.7"
+  resolved "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.10.7.tgz#a834d25f4c0e5ed0d16e5f37214048d1d359b849"
+  integrity sha512-GzlZONtIZrTQuDP74AMq8aqCfa1we08q6y3CL3KsY1RWKmqV0RoYuIGdF0keF7dUpr0hqmH4Lfk0jKTTPHGv1w==
   dependencies:
     node-libs-browser "^2.0.0"
     readline-sync "^1.4.7"
@@ -542,41 +542,41 @@ shadow-cljs@^2.9.10:
 
 source-map-support@^0.4.15:
   version "0.4.18"
-  resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  integrity sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
   dependencies:
     source-map "^0.5.6"
 
 source-map-support@^0.5.19:
   version "0.5.19"
-  resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map@^0.5.6:
   version "0.5.7"
-  resolved "https://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 source-map@^0.6.0:
   version "0.6.1"
-  resolved "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha1-dHIq8y6WFOnCh6jQu95IteLxomM=
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 stream-browserify@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.npm.taobao.org/stream-browserify/download/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
-  integrity sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=
+  resolved "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
+  integrity sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
 stream-http@^2.7.2:
   version "2.8.3"
-  resolved "https://registry.npm.taobao.org/stream-http/download/stream-http-2.8.3.tgz?cache=0&sync_timestamp=1588701397289&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstream-http%2Fdownload%2Fstream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
-  integrity sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=
+  resolved "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -586,43 +586,43 @@ stream-http@^2.7.2:
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
-  resolved "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
 timers-browserify@^2.0.4:
   version "2.0.11"
-  resolved "https://registry.npm.taobao.org/timers-browserify/download/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
-  integrity sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=
+  resolved "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
+  integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
   dependencies:
     setimmediate "^1.0.4"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.npm.taobao.org/to-arraybuffer/download/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+  resolved "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
 tty-browserify@0.0.0:
   version "0.0.0"
-  resolved "https://registry.npm.taobao.org/tty-browserify/download/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+  resolved "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
 ultron@~1.1.0:
   version "1.1.1"
-  resolved "https://registry.npm.taobao.org/ultron/download/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
-  integrity sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=
+  resolved "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
 
 url@^0.11.0:
   version "0.11.0"
-  resolved "https://registry.npm.taobao.org/url/download/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  resolved "https://registry.npmjs.org/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
   dependencies:
     punycode "1.3.2"
@@ -630,39 +630,39 @@ url@^0.11.0:
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
-  resolved "https://registry.npm.taobao.org/util-deprecate/download/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util@0.10.3:
   version "0.10.3"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.10.3.tgz?cache=0&sync_timestamp=1588238397004&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil%2Fdownload%2Futil-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  resolved "https://registry.npmjs.org/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
 util@^0.11.0:
   version "0.11.1"
-  resolved "https://registry.npm.taobao.org/util/download/util-0.11.1.tgz?cache=0&sync_timestamp=1588238397004&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil%2Fdownload%2Futil-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
-  integrity sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=
+  resolved "https://registry.npmjs.org/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
-  resolved "https://registry.npm.taobao.org/vm-browserify/download/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
-  integrity sha1-eGQcSIuObKkadfUR56OzKobl3aA=
+  resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
+  integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
 which@^1.3.1:
   version "1.3.1"
-  resolved "https://registry.npm.taobao.org/which/download/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=
+  resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 ws@^3.0.0:
   version "3.3.3"
-  resolved "https://registry.npm.taobao.org/ws/download/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  integrity sha1-8c+E/i1ekB686U767OeF8YeiKPI=
+  resolved "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
@@ -670,10 +670,10 @@ ws@^3.0.0:
 
 ws@^7.3.0:
   version "7.3.0"
-  resolved "https://registry.npm.taobao.org/ws/download/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
-  integrity sha1-Sy9/IZs9Nze8Gi+/FF2CW5TTj/0=
+  resolved "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
+  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
 
 xtend@^4.0.0:
   version "4.0.2"
-  resolved "https://registry.npm.taobao.org/xtend/download/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
-  integrity sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=
+  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
Added `respo.core/defplugin`. Now it can be used to replace `defn` in creating Hooks Plugin of Respo. `defplugin` has caches internally, which is like deps comparing in React hooks. However `defplugin` is based on `respo.caches` as a solution of memoizations.

`respo.caches` implemented a very simple caching mechanism for managing caches. 

```clojure
{:cold-duration 400, :trigger-loop 100, :elapse-loop 50}
```

After every 100(`:trigger-loop`) loops of rendering, GC will be triggered,

* if not hit happened in the past 50(`:eslapse-loop`) loops then the cache will be removed,
* if not any hit is ever happened then the cache will be removed.

It's a very simplicated solution and currently only applies to `defplugin`. In my plan components would switch to this solution as well for the consistency of caching.

And some more ideas written in Chinese, which might be more accurate. React 拥抱函数式编程, 但是没有使用函数式编程常用的 memoization 方案, 所有的组件复用都是基于上一次渲染匹配的, 如果存在 true/false 切换的场景, 隔代了就不能复用缓存了. 当然, memoization 也不够好, memoization 默认不做清除, 对于 UI 来说就是无限浪费内存了, 所以, 退化到类似 Caching 的方案, 手动控制数据缓存, 然后手动控制失效, 不失为一种可以尝试的方案.

Respo 当中需要这样一个方案, 是为了解决 Hooks 没有数据复用的问题, 之前版本的 Respo Hooks 就是没有缓存的, 是个隐患. 然而 React Hooks 当中为了这个问题, 就要求 Hooks 的顺序静态的, 从而保证根据 index 可以进行匹配, 我们都知道这对代码的灵活性有一定的损害. 而 Respo 从一开始就没有选择这种方案, 因而也就无法用相似的办法实现计算的复用. 从效率来说, React Hooks 能够做到 Hooks API 计算顺序的一一对应, 很可能是最高效的, 而 Respo 选择服务端处理请求所使用的缓存的方案, 必定有一定的性能损失.

不过从 Respo 自身看, 好处也有一些, 首先 Respo Hooks(更喜欢叫 Plugin) 的灵活性保住了, 其次, caching 的方案是在函数级别各自进行缓存处理, 借助了 Macro, 对代码的侵入性不大, 此前 Components Tree 的复用计算的处理中为了让位置能够一一对应, 树展开的代码带着 old-tree 并排展开, 代码挺啰嗦的, 借此机会可以做一次简化.

可以想象, 在性能和 GC 策略上大概率会存在问题, 好在 Respo 还是个试验性的方案, 可以逐步改进.