### PR TITLE
filter nil event handlers to fix unexpected event target

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Respo: A virtual DOM library in ClojureScript
 [![Respo](https://img.shields.io/clojars/v/respo/respo.svg)](https://clojars.org/respo/respo)
 
 ```clojure
-[respo "0.13.0-a2"]
+[respo "0.13.3-a1"]
 ```
 
 * Home http://respo-mvc.org

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1251,6 +1251,28 @@
                       |j $ {} (:type :expr) (:id |By6qpzeuKRY-) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:id |HyRcpMgOt0Kb) (:text |#{}) (:by |root) (:at 1504774121421)
+                  |n $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1596766606927)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1596766609367) (:text |filter) (:id |UN1CfUTlGh)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1596766609572)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1596766610546) (:text |fn) (:id |hj_aPVmPot)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1596766610870)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1596766611663)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1596766611897) (:text |[]) (:id |1NZ3o-IuMK)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1596766613685) (:text |k) (:id |SGWeoymiZD)
+                                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1596766614006) (:text |v) (:id |S574O2V_b5)
+                                :id |Ne4QNdCdU
+                            :id |Wd8oLMc4rO
+                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1596766615048)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1596766616020) (:text |some?) (:id |y0MRc7ld0-leaf)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1596766616793) (:text |v) (:id |JoXoyYqwn)
+                            :id |y0MRc7ld0-
+                        :id |XKznngXxyy
+                    :id |DlkfX28U5k
           |event->edn $ {} (:type :expr) (:id |BkJspGxdKAFZ) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:id |B1gsTzgdF0tW) (:text |defn) (:by |root) (:at 1504774121421)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respo",
-  "version": "0.13.2",
+  "version": "0.13.3-a1",
   "description": "Virtual DOM library",
   "main": "index.js",
   "scripts": {

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.13.2",
+{:version "0.13.3-a1",
  :group-id "respo",
  :artifact-id "respo",
  :skip-tag true,

--- a/src/respo/util/format.cljs
+++ b/src/respo/util/format.cljs
@@ -63,7 +63,7 @@
   (when (string/includes? x "?") (println "[Respo] warning: property contains `?` in" x))
   (case x "class-name" "class" "tab-index" "tabindex" "read-only" "readonly" x))
 
-(defn purify-events [events] (->> events keys (into #{})))
+(defn purify-events [events] (->> events (filter (fn [[k v]] (some? v))) keys (into #{})))
 
 (defn purify-element [markup]
   (cond


### PR DESCRIPTION
Respo resolves event by reading `coord`, which is attached to virtual DOM. It binds events on elements and find real virtual element in `@*global-element`. However, as introduced in Memof solution, virtual DOM might be reused although there coord might be different. Thus we get a wrong coord. It was not problem in the old time, but when there's an `{:click nil}`, it might first check there, and then use the same coord for checking parents, then we get the problem it resolving to the cached element's parents. So this fix tries to get rid of the nil events.