### PR TITLE
fix problem of number style values

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Respo: A virtual DOM library in ClojureScript
 [![Respo](https://img.shields.io/clojars/v/respo/respo.svg)](https://clojars.org/respo/respo)
 
 ```clojure
-[respo "0.13.8"]
+[respo "0.13.9"]
 ```
 
 * Home http://respo-mvc.org

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -298,6 +298,7 @@
                         |v $ {} (:type :leaf) (:text |mute-element) (:by |root) (:at 1504774121421)
                         |x $ {} (:type :leaf) (:text |ensure-string) (:by |root) (:at 1504774121421)
                         |y $ {} (:type :leaf) (:text |text->html) (:by |root) (:at 1504774121421)
+                        |yT $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291780486) (:text |get-style-value)
                 |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
                   :data $ {}
                     |T $ {} (:type :leaf) (:text |[]) (:by |root) (:at 1504774121421)
@@ -760,34 +761,31 @@
                                   |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291550895)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:text |last) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:text |entry) (:by |root) (:at 1504774121421)
+                                          |T $ {} (:type :expr) (:by nil) (:at 1504774121421)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:text |last) (:by |root) (:at 1504774121421)
+                                              |j $ {} (:type :leaf) (:text |entry) (:by |root) (:at 1504774121421)
+                                          |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291778389) (:text |get-style-value)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291554927) (:text |style-name)
+                                  |b $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291129389)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291131203) (:text |style-name)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291133775)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291133775) (:text |name)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291133775) (:text |k)
                               |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:text |str) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:text |name) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :leaf) (:text |k) (:by |root) (:at 1504774121421)
                                   |r $ {} (:type :leaf) (:text ||:) (:by |root) (:at 1504774121421)
-                                  |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:text |if) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:text |string?) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
-                                      |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:text |escape-html) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
-                                      |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:text |ensure-string) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
                                   |x $ {} (:type :leaf) (:text ||;) (:by |root) (:at 1504774121421)
+                                  |f $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291137245) (:text |style-name)
+                                  |t $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291536219)
+                                    :data $ {}
+                                      |D $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291536884) (:text |escape-html)
+                                      |b $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291556854) (:text |v)
                   |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |string/join) (:by |root) (:at 1504774121421)
@@ -1404,6 +1402,74 @@
                       |T $ {} (:type :leaf) (:text |assoc) (:by |root) (:at 1504774121421)
                       |j $ {} (:type :leaf) (:text |:event) (:by |root) (:at 1507356354798)
                       |r $ {} (:type :leaf) (:text |event) (:by |root) (:at 1504774121421)
+          |pattern-non-dimensional $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291094870)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291094870) (:text |def)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291094870) (:text |pattern-non-dimensional)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291094870)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291097891) (:text |new)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291101798) (:text |js/RegExp)
+                  |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613292362117) (:text "|\"acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera")
+                  |v $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291114369) (:text "|\"i")
+          |get-style-value $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291049013)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291049013) (:text |defn)
+              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291770963) (:text |get-style-value)
+              |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291049013)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291058025) (:text |x)
+                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291059502) (:text |style-name)
+              |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291056944)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |cond)
+                  |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291056944)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291056944)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |string?)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |x)
+                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |x)
+                  |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291056944)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291056944)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |keyword?)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |x)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291056944)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |name)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |x)
+                  |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291056944)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |:else)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291056944)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |str)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291056944) (:text |x)
+                  |t $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291060711)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291061110)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291063937) (:text |number?)
+                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291064270) (:text |x)
+                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291065820)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291066204) (:text |if)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291067120)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291069490) (:text |.test)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291082215) (:text |pattern-non-dimensional)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613292341586) (:text |style-name)
+                          |r $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291088580)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291089015) (:text |str)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291089435) (:text |x)
+                          |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291090868)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291091550) (:text |str)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291092067) (:text |x)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291093574) (:text "|\"px")
           |mute-element $ {} (:type :expr) (:by nil) (:at 1504774121421)
             :data $ {}
               |T $ {} (:type :leaf) (:text |defn) (:by |root) (:at 1504774121421)
@@ -1983,6 +2049,7 @@
                         |j $ {} (:type :leaf) (:text |dashed->camel) (:by |root) (:at 1504774121421)
                         |r $ {} (:type :leaf) (:text |event->prop) (:by |root) (:at 1504774121421)
                         |v $ {} (:type :leaf) (:text |ensure-string) (:by |root) (:at 1504774121421)
+                        |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291755213) (:text |get-style-value)
                 |v $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1612098222885)
                   :data $ {}
                     |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1612098223677) (:text |[])
@@ -2152,13 +2219,7 @@
                                       |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:text |dashed->camel) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:text |name) (:by |root) (:at 1504774121421)
-                                              |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:text |first) (:by |root) (:at 1504774121421)
-                                                  |j $ {} (:type :leaf) (:text |entry) (:by |root) (:at 1504774121421)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291711471) (:text |style-name)
                                   |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
@@ -2166,6 +2227,16 @@
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:text |last) (:by |root) (:at 1504774121421)
                                           |j $ {} (:type :leaf) (:text |entry) (:by |root) (:at 1504774121421)
+                                  |D $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291704235)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291705705) (:text |style-name)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291707648)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291707648) (:text |name)
+                                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291707648)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291707648) (:text |first)
+                                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291707648) (:text |entry)
                               |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:text |aset) (:by |root) (:at 1504774121421)
@@ -2175,18 +2246,11 @@
                                       |j $ {} (:type :leaf) (:text |element) (:by |root) (:at 1504774121421)
                                       |r $ {} (:type :leaf) (:text ||style) (:by |root) (:at 1504774121421)
                                   |r $ {} (:type :leaf) (:text |k) (:by |root) (:at 1504774121421)
-                                  |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
+                                  |x $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291720919)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:text |if) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:text |keyword?) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
-                                      |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:text |name) (:by |root) (:at 1504774121421)
-                                          |j $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
-                                      |v $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291723121) (:text |get-style-value)
+                                      |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291729622) (:text |style-name)
+                                      |b $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291730368) (:text |v)
                       |x $ {} (:type :expr) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |doseq) (:by |root) (:at 1504774121421)
@@ -2317,11 +2381,19 @@
                                       |T $ {} (:type :leaf) (:text |v) (:by |root) (:at 1504774121421)
                                       |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:text |ensure-string) (:by |root) (:at 1504774121421)
+                                          |T $ {} (:type :leaf) (:text |get-style-value) (:by |rJoDgvdeG) (:at 1613291786863)
                                           |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                             :data $ {}
                                               |T $ {} (:type :leaf) (:text |last) (:by |root) (:at 1504774121421)
                                               |j $ {} (:type :leaf) (:text |entry) (:by |root) (:at 1504774121421)
+                                          |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291183354) (:text |style-name)
+                                  |b $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291169112)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291171983) (:text |style-name)
+                                      |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291175422)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291175422) (:text |name)
+                                          |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291175422) (:text |k)
                               |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:text |str) (:by |root) (:at 1504774121421)
@@ -6147,6 +6219,7 @@
                         |j $ {} (:type :leaf) (:text |dashed->camel) (:by |root) (:at 1504774121421)
                         |r $ {} (:type :leaf) (:text |event->prop) (:by |root) (:at 1504774121421)
                         |v $ {} (:type :leaf) (:text |ensure-string) (:by |root) (:at 1504774121421)
+                        |x $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291812983) (:text |get-style-value)
                 |x $ {} (:type :expr) (:by nil) (:at 1504774121421)
                   :data $ {}
                     |T $ {} (:type :leaf) (:text |[]) (:by |root) (:at 1504774121421)
@@ -6790,27 +6863,32 @@
                     :data $ {}
                       |T $ {} (:type :expr) (:by nil) (:at 1504774121421)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:text |style-name) (:by |root) (:at 1504774121421)
+                          |T $ {} (:type :leaf) (:text |style-prop) (:by |rJoDgvdeG) (:at 1613291230288)
                           |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                             :data $ {}
                               |T $ {} (:type :leaf) (:text |dashed->camel) (:by |root) (:at 1504774121421)
-                              |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:text |name) (:by |root) (:at 1504774121421)
-                                  |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:text |key) (:by |root) (:at 1504774121421)
-                                      |j $ {} (:type :leaf) (:text |op) (:by |root) (:at 1504774121421)
+                              |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291235280) (:text |style-name)
                       |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |style-value) (:by |root) (:at 1504774121421)
                           |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:text |ensure-string) (:by |root) (:at 1504774121421)
+                              |T $ {} (:type :leaf) (:text |get-style-value) (:by |rJoDgvdeG) (:at 1613291810523)
                               |j $ {} (:type :expr) (:by nil) (:at 1504774121421)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:text |val) (:by |root) (:at 1504774121421)
                                   |j $ {} (:type :leaf) (:text |op) (:by |root) (:at 1504774121421)
+                              |r $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291242759) (:text |style-name)
+                      |D $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291215729)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291223509) (:text |style-name)
+                          |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291227639)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291227639) (:text |name)
+                              |j $ {} (:type :expr) (:by |rJoDgvdeG) (:at 1613291227639)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291227639) (:text |key)
+                                  |j $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613291227639) (:text |op)
                   |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |aset) (:by |root) (:at 1504774121421)
@@ -6818,7 +6896,7 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:text |.-style) (:by |root) (:at 1504774121421)
                           |j $ {} (:type :leaf) (:text |target) (:by |root) (:at 1504774121421)
-                      |r $ {} (:type :leaf) (:text |style-name) (:by |root) (:at 1504774121421)
+                      |r $ {} (:type :leaf) (:text |style-prop) (:by |rJoDgvdeG) (:at 1613291231922)
                       |v $ {} (:type :leaf) (:text |style-value) (:by |root) (:at 1504774121421)
           |rm-style $ {} (:type :expr) (:by nil) (:at 1504774121421)
             :data $ {}
@@ -9271,7 +9349,7 @@
                   |x $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |:opacity) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:text |0.2) (:by |root) (:at 1504774121421)
+                      |j $ {} (:type :leaf) (:text |0.2) (:by |rJoDgvdeG) (:at 1613291959523)
                   |v $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |:color) (:by |root) (:at 1504774121421)
@@ -9279,7 +9357,7 @@
                   |yj $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |:line-height) (:by |root) (:at 1504774121421)
-                      |j $ {} (:type :leaf) (:text |1.4) (:by |root) (:at 1504774121421)
+                      |j $ {} (:type :leaf) (:text "|\"1.4em") (:by |rJoDgvdeG) (:at 1613291331109)
                   |yx $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |:max-width) (:by |root) (:at 1504774121421)
@@ -9295,7 +9373,7 @@
                   |r $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |:background-color) (:by |root) (:at 1504774121421)
-                      |b $ {} (:type :leaf) (:by |root) (:at 1539015843887) (:text "|\"hsl(240,100%,0%)")
+                      |b $ {} (:type :leaf) (:by |rJoDgvdeG) (:at 1613292495673) (:text "|\"hsl(240,100%,0%)")
                   |y $ {} (:type :expr) (:by nil) (:at 1504774121421)
                     :data $ {}
                       |T $ {} (:type :leaf) (:text |:font-size) (:by |root) (:at 1504774121421)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respo",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "Virtual DOM library",
   "main": "index.js",
   "scripts": {
@@ -29,8 +29,8 @@
   "homepage": "https://github.com/Respo/respo#readme",
   "dependencies": {},
   "devDependencies": {
-    "shadow-cljs": "^2.11.15",
+    "shadow-cljs": "^2.11.18",
     "source-map-support": "^0.5.19",
-    "ws": "^7.4.2"
+    "ws": "^7.4.3"
   }
 }

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.13.8",
+{:version "0.13.9",
  :group-id "respo",
  :artifact-id "respo",
  :skip-tag true,

--- a/src/respo/comp/inspect.cljs
+++ b/src/respo/comp/inspect.cljs
@@ -25,7 +25,7 @@
    :opacity 0.2,
    :font-size "12px",
    :font-family "Avenir,Verdana",
-   :line-height 1.4,
+   :line-height "1.4em",
    :padding "2px 6px",
    :border-radius "4px",
    :max-width 160,

--- a/src/respo/render/dom.cljs
+++ b/src/respo/render/dom.cljs
@@ -1,7 +1,9 @@
 
 (ns respo.render.dom
   (:require [clojure.string :as string]
-            [respo.util.format :refer [dashed->camel event->prop ensure-string]]
+            [respo.util.format
+             :refer
+             [dashed->camel event->prop ensure-string get-style-value]]
             [respo.util.detect :refer [component?]]))
 
 (defn make-element [virtual-element listener-builder coord]
@@ -21,8 +23,8 @@
         (let [k (dashed->camel (name (first entry))), v (last entry)]
           (if (some? v) (aset element k v))))
       (doseq [entry style]
-        (let [k (dashed->camel (name (first entry))), v (last entry)]
-          (aset (aget element "style") k (if (keyword? v) (name v) v))))
+        (let [style-name (name (first entry)), k (dashed->camel style-name), v (last entry)]
+          (aset (aget element "style") k (get-style-value v style-name))))
       (doseq [event-name (keys (:event virtual-element))]
         (let [name-in-string (event->prop event-name)]
           (comment println "listener:" event-name name-in-string)
@@ -37,5 +39,8 @@
   (->> styles
        (map
         (fn [entry]
-          (let [k (first entry), v (ensure-string (last entry))] (str (name k) ":" v ";"))))
+          (let [k (first entry)
+                style-name (name k)
+                v (get-style-value (last entry) style-name)]
+            (str (name k) ":" v ";"))))
        (string/join "")))

--- a/src/respo/render/html.cljs
+++ b/src/respo/render/html.cljs
@@ -3,7 +3,12 @@
   (:require [clojure.string :as string]
             [respo.util.format
              :refer
-             [prop->attr purify-element mute-element ensure-string text->html]]
+             [prop->attr
+              purify-element
+              mute-element
+              ensure-string
+              text->html
+              get-style-value]]
             [respo.util.detect :refer [component? element?]]))
 
 (defn escape-html [text]
@@ -19,8 +24,10 @@
   (->> styles
        (map
         (fn [entry]
-          (let [k (first entry), v (last entry)]
-            (str (name k) ":" (if (string? v) (escape-html v) (ensure-string v)) ";"))))
+          (let [k (first entry)
+                style-name (name k)
+                v (get-style-value (last entry) style-name)]
+            (str style-name ":" (escape-html v) ";"))))
        (string/join "")))
 
 (defn entry->string [entry]

--- a/src/respo/render/patch.cljs
+++ b/src/respo/render/patch.cljs
@@ -1,7 +1,9 @@
 
 (ns respo.render.patch
   (:require [clojure.string :as string]
-            [respo.util.format :refer [dashed->camel event->prop ensure-string]]
+            [respo.util.format
+             :refer
+             [dashed->camel event->prop ensure-string get-style-value]]
             [respo.render.dom :refer [make-element style->string]]
             [respo.schema.op :as op]))
 
@@ -24,8 +26,10 @@
       (aset target prop-name prop-value))))
 
 (defn add-style [target op]
-  (let [style-name (dashed->camel (name (key op))), style-value (ensure-string (val op))]
-    (aset (.-style target) style-name style-value)))
+  (let [style-name (name (key op))
+        style-prop (dashed->camel style-name)
+        style-value (get-style-value (val op) style-name)]
+    (aset (.-style target) style-prop style-value)))
 
 (defn append-element [target op listener-builder coord]
   (let [new-element (make-element op listener-builder coord)]

--- a/src/respo/util/format.cljs
+++ b/src/respo/util/format.cljs
@@ -49,6 +49,16 @@
 
 (defn event->string [x] (subs (name x) 3))
 
+(def pattern-non-dimensional
+  (new js/RegExp "acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera" "i"))
+
+(defn get-style-value [x style-name]
+  (cond
+    (string? x) x
+    (keyword? x) (name x)
+    (number? x) (if (.test pattern-non-dimensional style-name) (str x) (str x "px"))
+    :else (str x)))
+
 (defn mute-element [element]
   (if (component? element)
     (update element :tree mute-element)

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
@@ -40,7 +40,7 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
-brorand@^1.0.1:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -224,17 +224,17 @@ domain-browser@^1.1.1:
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
 elliptic@^6.5.3:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
-  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
   dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
     hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
 
 events@^3.0.0:
   version "3.2.0"
@@ -266,7 +266,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hmac-drbg@^1.0.0:
+hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
@@ -332,7 +332,7 @@ minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
+minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
@@ -533,10 +533,10 @@ shadow-cljs-jar@1.3.2:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
   integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
 
-shadow-cljs@^2.11.15:
-  version "2.11.15"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.11.15.tgz#d81663f0a286fb193c93cd0cb7baa63ded928ef3"
-  integrity sha512-bqZ/9v178vF3YBLGayr/66HdelRVOaYb657jqsz7Z3XPXIjN5lyL+ljDFIx5qC7endX/itO7tPn4PmLx7ToJlw==
+shadow-cljs@^2.11.18:
+  version "2.11.18"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.11.18.tgz#f83fe776c9001afdf92611e6bef6da8aed926aab"
+  integrity sha512-7EAXl1xk2GjhViUeexn7cqAPx0lkEl2J40nAbPPCrAbfLfOWn5tjV4P3Be6IqTInSHMx04tFxDRV+0xFdIhl5A==
   dependencies:
     node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"
@@ -673,10 +673,10 @@ ws@^3.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@^7.4.2:
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
-  integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
+ws@^7.4.3:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
+  integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
Related to https://github.com/Respo/respo.calcit/pull/18 .

HTML pages with `<!DOCTYPE HTML>` does not accept number values. That would look like a bug.
